### PR TITLE
Item fix - only create item once

### DIFF
--- a/bio/sources/wormbase-acedb/main/src/org/intermine/bio/dataconversion/WormbaseAcedbConverter.java
+++ b/bio/sources/wormbase-acedb/main/src/org/intermine/bio/dataconversion/WormbaseAcedbConverter.java
@@ -13,15 +13,14 @@ package org.intermine.bio.dataconversion;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.io.Reader;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.regex.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -29,8 +28,12 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.lang.StringUtils;
-import org.intermine.dataconversion.*;
-import org.intermine.metadata.*;
+import org.intermine.dataconversion.ItemWriter;
+import org.intermine.metadata.ClassDescriptor;
+import org.intermine.metadata.CollectionDescriptor;
+import org.intermine.metadata.FieldDescriptor;
+import org.intermine.metadata.Model;
+import org.intermine.metadata.ReferenceDescriptor;
 // import org.intermine.util.TypeUtil;
 import org.intermine.metadata.TypeUtil; //Paulo Nuin 2016
 import org.intermine.xml.full.Item;
@@ -39,25 +42,27 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXParseException;
 
-import wormbase.model.parser.*;
-import org.intermine.bio.dataconversion.MappingFileKey;
+import wormbase.model.parser.DataMapper;
+import wormbase.model.parser.FileParser;
+import wormbase.model.parser.PackageUtils;
+import wormbase.model.parser.WMDebug;
 
 /**
  * Mapping file format:
  * primaryIdentifier = /Variation/text()[1]
- * 
+ *
  * if.naturalVariant = /XPATH/...
  * returns true if xpath returns any nodes at all
- * 
+ *
  * type casting allowed
  * (Phenotype)parents		= /XPATH/...
- * 
+ *
  * @author
  */
 public class WormbaseAcedbConverter extends BioFileConverter
 {
-    
-	private String currentClass = null; 
+
+	private String currentClass = null;
 	private String rejectFilePath = null;
 	private String keyFilePath = null;
 
@@ -68,14 +73,14 @@ public class WormbaseAcedbConverter extends BioFileConverter
     private WMDebug wmd;
     private DataMapper dataMapping = null;
     private Model model;
-    private ClassDescriptor classCD; // CD of current data type being processed 
-    
+    private ClassDescriptor classCD; // CD of current data type being processed
+
     // Items that have already been referenced and stored
     // Key: "className:id", Value: Item ID (ex: "WBGene12345")
-	private HashMap<String, Item> storedRefItems; 
-	
+	private HashMap<String, Item> storedRefItems;
+
 	private HashMap<String, String> keyMapping; // the primary key for each class
-	
+
     /**
      * Constructor
      * @param writer the ItemWriter used to handle the resultant items
@@ -83,39 +88,39 @@ public class WormbaseAcedbConverter extends BioFileConverter
      */
     public WormbaseAcedbConverter(ItemWriter writer, Model _model) {
         super(writer, _model, DATA_SOURCE_NAME, DATASET_TITLE);
-        
+
         wmd = new WMDebug();
         //wmd.off(); // turn on for debug output // TODO toggle switch
-        
+
         wmd.debug("Constructor called");
-        
+
         storedRefItems = new HashMap<String, Item>();
         model = _model;
-        
-        
+
+
     }
 
     /**
-     * 
+     *
      * @param reader The java.io.BufferedReader that intermine passes in
      * {@inheritDoc}
      */
     public void process(Reader reader) throws Exception {
-    	wmd.debug("started WormbaseAcedbConverter.process()"); 
-    	
+    	wmd.debug("started WormbaseAcedbConverter.process()");
+
     	// Checking for properties
     	if( dataMapping == null )
     		throw new Exception("mapping.file property not defined for this"+
     				" source in the project.xml");
-    	
+
     	if( keyMapping == null )
     		throw new Exception("key.file property not defined for this"+
     				" source in the project.xml");
-    	
+
     	if( currentClass == null )
     		throw new Exception("source.class property not defined for this"+
     				" source in the project.xml");
-    	
+
     	if( rejectFilePath == null )
     	{
 			wmd.debug("rejects.file property not set, rejected XML"+
@@ -128,20 +133,20 @@ public class WormbaseAcedbConverter extends BioFileConverter
 		if(rejectFilePath != null)
 			rejectsFW = new FileWriter(rejectFilePath); // creates file if exists
 		FileParser fp = new FileParser(reader);
-    	
-		
-	
+
+
+
 		//// Process properties file first ////
 		wmd.debug("Parsing mapping file...");
-		
+
 		HashMap<MappingFileKey, XPathExpression> prop2XpathExpr = new HashMap<MappingFileKey, XPathExpression>();
 	    // Get XPathFactory
         XPathFactory xpf = XPathFactory.newInstance();
         XPath xpath = xpf.newXPath();
-    	
+
         // Get enumerator of InterMine datapaths to map (ex: primaryIdentifier)
         Enumeration<Object> dataPathEnum = dataMapping.keys();
-        
+
     	wmd.debug("=== Mapping file entries ===");
         String rawPropKey;
         MappingFileKey PIDKey = null;
@@ -150,44 +155,44 @@ public class WormbaseAcedbConverter extends BioFileConverter
         	if(rawPropKey.length() == 0){
         		continue;
         	}
-        	
+
         	MappingFileKey propKey = new MappingFileKey(rawPropKey);
-        	
+
         	wmd.debug("=== "+propKey.getRawKey()+" ===");
         	wmd.debug("cast type: "+propKey.getCastType());
         	wmd.debug("datapath: "+propKey.getDataPath());
 
-        	
+
         	String xpathQuery = dataMapping.getProperty(rawPropKey); // ex: "/Transcript/text()[1]"
-        	
+
         	// The XPath object compiles the XPath expression
 	        XPathExpression expr = xpath.compile( xpathQuery );
-	        
+
 	        if(rawPropKey.equals(getClassPIDField(classCD.getSimpleName()))){
 	        	PIDKey = propKey;
 	        }
 	        prop2XpathExpr.put(propKey, expr);
         }
     	wmd.debug("=== ==================== ===");
-        
-        Pattern strB4Dot = 		Pattern.compile("(.*?)\\.(.*)");
-	        
+
+        Pattern strB4Dot = Pattern.compile("(.*?)\\.(.*)");
+
     	// foreach XML string
     	String xmlChunk;
-    	int count=0; // 
+    	int count=0; //
     	while( (xmlChunk = fp.getDataString()) != null ){
-		
+
     		count++;
     		wmd.debug("###========== NEW OBJECT ==========###");
-    		
+
 //    		if(count < 1070){
 //    			System.out.println(String.valueOf(count)+":"+xmlChunk.length());
 //    			continue;
 //    		}
-    		
+
     		Document doc;
     		try{
-				// Load XML into org.w3c.dom.Document 
+				// Load XML into org.w3c.dom.Document
 				doc = PackageUtils.loadXMLFrom(xmlChunk);
     		}catch(SAXParseException e){
     			try{
@@ -196,10 +201,10 @@ public class WormbaseAcedbConverter extends BioFileConverter
     				doc = PackageUtils.loadXMLFrom(repairedData);
     			}catch( SAXParseException e1 ){
 	    			try{
-	    				
+
 	    				if(rejectFilePath != null){
 		    				wmd.log("### SANITATION FAILED: ADDING RECORD TO REJECTS FILE ###");
-		    				
+
 		    				// Add to rejects file
 			    			rejectsFW.write(xmlChunk);
 			    			rejectsFW.write("\n\n");
@@ -211,11 +216,11 @@ public class WormbaseAcedbConverter extends BioFileConverter
 	    			continue;
     			}
     		}
-			
-	        
+
+
 	        Item item = createItem(currentClass);
 	        wmd.debug("New IMID: "+item.getIdentifier());
-	        
+
 	        Iterator prop2XpathExprIter = prop2XpathExpr.keySet().iterator();
 	        String ID = null;
 	        String castType = null;
@@ -228,19 +233,19 @@ public class WormbaseAcedbConverter extends BioFileConverter
 	        	}else{
 	        		propKey = PIDKey;
 	        	}
-	        	
-	        	
+
+
 	        	assertIfExists = false;
 	        	castType = null;
-	        	
+
 	        	wmd.debug("Retrieving:["+propKey.getRawKey()+"]");
-	        	
+
 	        	// Get casted type if exists ex: (Gene)/XPath/statement/here
-	        	
-	        	
+
+
 	        	// The XPath object compiles the XPath expression
 	        	XPathExpression expr = prop2XpathExpr.get(propKey);
-		        
+
 		        Matcher fNMatcher = strB4Dot.matcher(propKey.getDataPath());
 			    String fieldName;
 		        String suffix = ""; // after .
@@ -258,33 +263,33 @@ public class WormbaseAcedbConverter extends BioFileConverter
 		        	fieldName = propKey.getDataPath();
 		        }
 	        	wmd.debug("fieldname="+fieldName);
-		        
-		        		
+
+
 		        // '.' indicates join, aka reference or collection
-	        	
-	        	
-	        	
-	        	
-	        	
+
+
+
+
+
 //		       	wmd.debug("This is an attribute");
-	        	
-		        
-		        
-		        
-	        	
-	        	
+
+
+
+
+
+
 		        FieldDescriptor fd = classCD.getFieldDescriptorByName(fieldName);
 		        if( fd == null ){
 		        	throw new Exception(classCD.getName()+"."+fieldName+" not found in model");
 		        }
-		        
+
 		        if(fd.isAttribute()){
-		        	
+
 		        	if(assertIfExists){
 			        	NodeList resultNode = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
-			        	
+
 			        	wmd.debug(String.valueOf(resultNode.getLength()));
-			        	
+
 		        		if(resultNode.getLength() == 0){
 		        			wmd.debug(fieldName+"=false");
 		        			item.setAttribute(fieldName, "false");
@@ -292,9 +297,9 @@ public class WormbaseAcedbConverter extends BioFileConverter
 		        			wmd.debug(fieldName+"=true");
 		        			item.setAttribute(fieldName, "true");
 		        		}
-		        		
+
 		        	}else{
-		        	
+
 			        	String xPathValue = StringUtils.strip( expr.evaluate(doc) );
 			        	wmd.debug("xpathvalue:"+xPathValue);
 				        if(fieldName.equals(getClassPIDField(classCD.getSimpleName()))){
@@ -311,9 +316,9 @@ public class WormbaseAcedbConverter extends BioFileConverter
 				        	}else{
 				        		continue;
 				        	}
-				        	
+
 				        }
-				        
+
 			        	// DataPath describes attribute
 				        if (!StringUtils.isEmpty(xPathValue)) {
 							wmd.debug("Setting attribute ["+fieldName+"] to ["+xPathValue+"]");
@@ -321,26 +326,26 @@ public class WormbaseAcedbConverter extends BioFileConverter
 						}else{
 							wmd.debug("ignoring attribute ["+fieldName+"], no value");
 						}
-				        
+
 		        	}
-		        	
+
 		        }else{
-		        	
-		        	ReferenceDescriptor rd = (ReferenceDescriptor) fd; 
-		        	
+
+		        	ReferenceDescriptor rd = (ReferenceDescriptor) fd;
+
 		        	String refClassName;
         			if(propKey.getCastType() != null){
         				refClassName = propKey.getCastType();
         			}else{
 			        	refClassName = TypeUtil.unqualifiedName(rd.getReferencedClassName());
         			}
-		        	
-		        	
+
+
 		        	if( rd.relationType() == FieldDescriptor.ONE_ONE_RELATION ||
 		        		rd.relationType() == FieldDescriptor.N_ONE_RELATION   )
 		        	{
 	//			        		wmd.debug("This is a reference");
-		        		
+
 		        		String xPathValue = StringUtils.strip( expr.evaluate(doc) );
 			        	Item referencedItem;
 		        		if(!xPathValue.isEmpty()){
@@ -350,10 +355,10 @@ public class WormbaseAcedbConverter extends BioFileConverter
 			        		wmd.debug("=======================");
 			        		continue;
 			        	}
-			        	
+
 			        	wmd.debug("Setting current "+currentClass+"."+fd.getName()+" to: ("+refClassName+")["+xPathValue+"]" );
 			        	item.setReference(rd.getName(), referencedItem.getIdentifier());
-			        	
+
 			        	if( 		rd.relationType() == FieldDescriptor.ONE_ONE_RELATION ){
 	//				        		wmd.debug("1:1");
 			        		setRevRefIfExists(item, referencedItem, rd);
@@ -361,20 +366,20 @@ public class WormbaseAcedbConverter extends BioFileConverter
 	//				        		wmd.debug("N:1");
 			        		addToRevColIfExists(item, referencedItem, rd);
 			        	}
-		        		
+
 		        	}else if( rd.isCollection() ){
-	//			        		wmd.debug("This is a collection"); 
+	//			        		wmd.debug("This is a collection");
 		        		CollectionDescriptor cd = (CollectionDescriptor) rd;
-		        		
+
 		        		//if(cd.relationType() == FieldDescriptor.ONE_N_RELATION ){wmd.debug("1:N");}else if(cd.relationType() == FieldDescriptor.M_N_RELATION){wmd.debug("M:N");}
-		        		
-		        		Item referencedItem = createItem(refClassName); // Initialized by necessity
-		        		
+
+
+
 			        	// Get set of IDs referenced
 				        NodeList resultNodes = (NodeList) expr.evaluate(doc,  XPathConstants.NODESET);
-				        String collectionIDs[] = new String[resultNodes.getLength()]; 
+				        String collectionIDs[] = new String[resultNodes.getLength()];
 				        for(int i = 0; i < resultNodes.getLength(); i++) {
-				            
+
 				        	// If the first child is a text node, uses that instead of resolving
 				        	//   whole node (and descendants) to text
 				        	Node resultNode = resultNodes.item(i);
@@ -389,21 +394,22 @@ public class WormbaseAcedbConverter extends BioFileConverter
 				        		nodeText = resultNode.getTextContent();
 				        	}
 				        	//wmd.debug("ASDF::"+String.valueOf(resultNode.getNodeType())+"--"+Node.ELEMENT_NODE); // DELETE
-				        	
-				        	collectionIDs[i] = StringUtils.strip(nodeText); 
-			        		
+
+				        	collectionIDs[i] = StringUtils.strip(nodeText);
+
+				        	Item referencedItem;
 			        		if(!collectionIDs[i].isEmpty()){
 				        		referencedItem = getRefItem(refClassName, collectionIDs[i]);
 				        	}else{
 				        		wmd.debug("ID not defined, moving on...");
 				        		continue;
 				        	}
-	
-			        		
+
+
 			        		item.addToCollection(cd.getName(), referencedItem);
-			        		
+
 				            wmd.debug(cd.getName()+":["+collectionIDs[i]+"]");
-		        		
+
 			        		if( 		cd.relationType() == FieldDescriptor.ONE_N_RELATION ){
 			        			setRevRefIfExists(item, referencedItem, cd);
 			        		}else if(	cd.relationType() == FieldDescriptor.M_N_RELATION   ){
@@ -420,45 +426,45 @@ public class WormbaseAcedbConverter extends BioFileConverter
         		firstPass = false;
 		        wmd.debug("=======================");
 	        }
-	        
+
 	        if( ID == null ){
 	        	throw new Exception(getClassPIDField(classCD.getSimpleName())+
 	        			" set as class ID but not defined. Record ending at line:"+fp.getCurrentLine());
 	        }
 //	        wmd.debug("Storing "+currentClass+" with ID:"+ID);
 //	        store(item);
-	        
+
         	setRefItem(currentClass, ID, item);
-	    	
+
 	        // TODO remove in final build
 //	        if(count == 100){
 //		        wmd.debug("STOP AFTER 100 RECORDS FOR TESTING");
 //		        break;
 //	        }
     	}
-    	
+
     	wmd.debug("==== Flushing cached reference items ====");
     	// Store all items in storedRefItems
-    	Iterator<Entry<String, Item>> keySetIter = 
+    	Iterator<Entry<String, Item>> keySetIter =
     			storedRefItems.entrySet().iterator();
     	while(keySetIter.hasNext()){
     		Entry<String, Item> keySet = keySetIter.next();
     		wmd.debug("Storing item:["+keySet.getKey()+"]");
     		store(keySet.getValue());
     	}
-    
+
 		if(rejectFilePath != null)
 			rejectsFW.close();
-    	
+
     }
-    
+
     /**
      * Gets ID of referenced object if exists.  It it doesn't exist, creates it
      * and returns ID of newly created object.
-     * @param fieldName The reference or collection this object is referred to in 
+     * @param fieldName The reference or collection this object is referred to in
      * @param pID Primary ID value of referenced object
      * @return InterMine item identifier for this object
-     * @throws Exception 
+     * @throws Exception
      */
 	public Item getRefItem(String className, String pID) throws Exception {
 //    	ReferenceDescriptor rd = classCD.getReferenceDescriptorByName(fieldName, true);
@@ -468,8 +474,8 @@ public class WormbaseAcedbConverter extends BioFileConverter
     	if( pID == null ){
     		throw new Exception("getRefID pID parameter is null");
     	}
-    	
-		Item referencedItem; 
+
+		Item referencedItem;
 		if (storedRefItems.containsKey(className + ":" + pID)) {
 			referencedItem = storedRefItems.get(className + ":"
 					+ pID);
@@ -481,7 +487,7 @@ public class WormbaseAcedbConverter extends BioFileConverter
 		}
 		return referencedItem;
 	}
-	
+
 	/**
 	 * Stores item in working buffer, overwriting any existing pairs.  Buffer
 	 * is flushed once all items are dealt with.
@@ -499,7 +505,7 @@ public class WormbaseAcedbConverter extends BioFileConverter
     	}
     	storedRefItems.put(className+":"+pID, item);
 	}
-	
+
 	public boolean itemHasBeenProcessed(String className, String pID) throws Exception {
 //    	ReferenceDescriptor rd = classCD.getReferenceDescriptorByName(fieldName, true);
     	if( className == null ){
@@ -508,21 +514,21 @@ public class WormbaseAcedbConverter extends BioFileConverter
     	if( pID == null ){
     		throw new Exception("getRefID pID parameter is null");
     	}
-    	
-		Item referencedItem; 
+
+		Item referencedItem;
 		if (storedRefItems.containsKey(className + ":" + pID)) {
 			return true;
 		} else {
 			return false;
 		}
 	}
-	
+
 	// TODO configure two part keys
 	public String getClassPIDField(String className) throws Exception{
 		if (keyMapping.containsKey(className)) {
 			return keyMapping.get(className);
-		} 
-		
+		}
+
 		throw new Exception(
 				"keyMapping hash has no \"class key value\" for "
 				+ className + ". Add a " + className + ".key property in "
@@ -530,11 +536,11 @@ public class WormbaseAcedbConverter extends BioFileConverter
 	}
 
 	/**
-	 * This method is automatically called if "mapping.file" property set 
+	 * This method is automatically called if "mapping.file" property set
 	 * for source in project XML.
-	 * 
+	 *
 	 * Reads InterMine to AceXML data mapping configuration file
-	 * @param mappingFile 
+	 * @param mappingFile
 	 * @throws Exception
 	 */
     public void setMappingFile(String mappingFile) throws Exception{
@@ -547,28 +553,28 @@ public class WormbaseAcedbConverter extends BioFileConverter
 		}
     	System.out.println("Processed mapping file: "+mappingFile);
     }
-    
+
     /**
-	 * This method is automatically called if "key.file" property set 
+	 * This method is automatically called if "key.file" property set
 	 * for source in project XML.
-	 * 
+	 *
 	 * Reads key/value file loader will use.
 	 * File must be in the format
-	 * 
+	 *
 	 * className.key = value
-	 * 
+	 *
 	 * For example:
 	 * BioEntity.key = primaryIdentifier
 	 * This line will set the primaryIdentifier field as primary key
 	 * for all children of BioEntity.  Precedence granted to more
 	 * specific keys.
-	 * 
+	 *
      * @param keyFilePath
      * @throws Exception
      */
     public void setKeyFile(String keyFilePath) throws Exception{
     	System.out.println("keyFilePath");
-    	this.keyFilePath = keyFilePath; 
+    	this.keyFilePath = keyFilePath;
         keyMapping = new HashMap<String, String>();
     	Properties keyFileProps = new Properties();
     	try{
@@ -583,70 +589,70 @@ public class WormbaseAcedbConverter extends BioFileConverter
     		String key = (String) keyEnum.nextElement();
     		int index = key.indexOf(".key");
 			if(index > 0){
-    			keyMapping.put( key.substring(0, index), 
+    			keyMapping.put( key.substring(0, index),
     							keyFileProps.getProperty(key));
-    			
+
     		}
     	}
     	System.out.println("Processed key file: ["+keyFilePath+"]");
     }
-    
+
     /**
-	 * This method is automatically called if "key.file" property set 
+	 * This method is automatically called if "key.file" property set
 	 * for source in project XML.
-	 * 
+	 *
 	*/
     public void setDataType(String dataType){
-    	
+
     }
-    
+
     /**
-     * Sets the reverse reference of referenced classes of 1:1 and N:1 
+     * Sets the reverse reference of referenced classes of 1:1 and N:1
      * relationships.
      * @param currentItem The item whose fields are being processed.
      * @param referencedItem The item the currentItem's reference points to
-     * @param rd Descriptor for currentItem's current reference being processed 
+     * @param rd Descriptor for currentItem's current reference being processed
      * @param refPID The primary ID intended to be set for referencedItem
      */
-    public void setRevRefIfExists(Item currentItem, Item referencedItem, 
+    public void setRevRefIfExists(Item currentItem, Item referencedItem,
     		ReferenceDescriptor rd){
     	ReferenceDescriptor rrd = rd.getReverseReferenceDescriptor();
 		if(rrd == null){
 //			wmd.debug("Unidirectional, no reverse reference");
 		}else{
 //			wmd.debug(String.format(
-//					"Setting (%s)%s.%s= current item", 
-//					rd.getName(), rd.getReferencedClassName(), 
+//					"Setting (%s)%s.%s= current item",
+//					rd.getName(), rd.getReferencedClassName(),
 //					rrd.getName()));
 			referencedItem.setReference(rrd.getName(), currentItem);
 		}
     }
-    
-    public void addToRevColIfExists(Item currentItem, Item referencedItem, 
+
+    public void addToRevColIfExists(Item currentItem, Item referencedItem,
     		ReferenceDescriptor rd){
     	CollectionDescriptor rcd = (CollectionDescriptor) rd.getReverseReferenceDescriptor();
 		if(rcd == null){
 //			wmd.debug("Unidirectional, no reverse reference");
 		}else{
 //			wmd.debug(String.format(
-//					"Adding current item to (%s)%s.%s", 
-//					rd.getName(), rd.getReferencedClassName(), 
+//					"Adding current item to (%s)%s.%s",
+//					rd.getName(), rd.getReferencedClassName(),
 //					rcd.getName()));
 			referencedItem.addToCollection(rcd.getName(), currentItem);
 		}
 
     }
-    
+
     public void setSourceClass(String sourceClass){
     	currentClass = sourceClass;
-        
-        classCD = model.getClassDescriptorByName(currentClass); 
+
+        classCD = model.getClassDescriptorByName(currentClass);
     }
-    
+
     public void setRejectsFile(String rejectsFile){
     	rejectFilePath = rejectsFile;
     }
-    
+
     public void setDebug(String debug){
     	if(debug.equalsIgnoreCase("true")){
     		wmd.on();
@@ -655,18 +661,18 @@ public class WormbaseAcedbConverter extends BioFileConverter
     		wmd.log("debug: off");
     	}
     }
-    
+
     /**
-     * Sets the dataset for this instance 
+     * Sets the dataset for this instance
      * @param datasource
      */
     // public void setDataSet(String dataSet){
     // 	System.out.println("DataSet set to:"+dataSet); // DELETE
     // 	String dataSourceRefID = getDataSource(DATA_SOURCE_NAME);
     //     String dataSetRefID = getDataSet(dataSet, dataSourceRefID);
-    	
+
     // 	BioStoreHook hook = (BioStoreHook) this.storeHook;
     // 	hook.setDataSet(dataSetRefID);
     // } Paulo Nuin 2016
-    
+
  }

--- a/bio/sources/wormbase-acedb/test/resources/WormbaseAcedbConverterTest_tgt.xml
+++ b/bio/sources/wormbase-acedb/test/resources/WormbaseAcedbConverterTest_tgt.xml
@@ -10,12 +10,6 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="5_76" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275470"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_62"/></collection>
-</item>
 <item id="3_98" class="Strain">
 <attribute name="CGCReceived" value="2011-01-06"/>
 <attribute name="genotype" value="rmIs175."/>
@@ -28,130 +22,93 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_71" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00006765"/>
+<item id="5_49" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275468"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/></collection>
+</item>
+<item id="4_55" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009717"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_59"/></collection>
+<collection name="strains"><reference ref_id="3_65"/></collection>
 </item>
 <item id="3_32" class="Strain">
 <attribute name="primaryIdentifier" value="AGK51"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_112" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00016329"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_88"/></collection>
-</item>
 <item id="3_9" class="Strain">
 <attribute name="primaryIdentifier" value="AGD745"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_107" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00001843"/>
+<item id="4_59" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002018"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_84"/></collection>
+<collection name="strains"><reference ref_id="3_68"/><reference ref_id="3_69"/></collection>
 </item>
-<item id="3_72" class="Strain">
-<attribute name="CGCReceived" value="2012-05-01"/>
-<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs4."/>
+<item id="3_37" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="zfp-1(ok554) unc-119(ed3) III; armEx14."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson4598"/>
 <attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="ALF4"/>
-<attribute name="remark" value="bafIs4 [daf-12 fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="primaryIdentifier" value="AGK280"/>
+<attribute name="remark" value="armEx14 [PHD1-PHD2::FLAG + zfp-1(short isoform) + unc-119(+)]. Pick non-Unc animals to maintain. The fosmid-based armEx14 transgene rescues zfp-1(ok554)/nDf17 lethality. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
+<collection name="genes"><reference ref_id="4_17"/><reference ref_id="4_23"/></collection>
+<collection name="variations"><reference ref_id="5_20"/><reference ref_id="5_15"/></collection>
 </item>
-<item id="3_27" class="Strain">
-<attribute name="CGCReceived" value="2014-04-25"/>
-<attribute name="genotype" value="daf-16(mu86) I; glp-1(e2141) III; uthEx649."/>
+<item id="5_20" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091841"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
+</item>
+<item id="5_77" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241620"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_88"/></collection>
+</item>
+<item id="3_62" class="Strain">
+<attribute name="CGCReceived" value="2003-12-16"/>
+<attribute name="genotype" value="sra-13(zh13) II."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson18908"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGD1048"/>
-<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x8"/>
+<attribute name="primaryIdentifier" value="AH159"/>
+<attribute name="remark" value="sra-13(zh13) mutants display stronger chemotaxis to limiting concentrations of isoamylalcohol and diacetyl than WT animals. Deletion allele. 396 bp of 5' promoter sequence and all but the last exon are removed; probably a null allele."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_32"/><reference ref_id="4_28"/></collection>
-<collection name="variations"><reference ref_id="5_31"/><reference ref_id="5_27"/></collection>
+<collection name="genes"><reference ref_id="4_44"/></collection>
+<collection name="variations"><reference ref_id="5_43"/></collection>
 </item>
-<item id="5_31" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00089216"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
-</item>
-<item id="3_78" class="Strain">
-<attribute name="CGCReceived" value="2012-05-01"/>
-<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs62."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson14558"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="ALF82"/>
-<attribute name="remark" value="bafIs62 [lin-42p::GFP + unc-119(+)]. lin-42p::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+). Array was crossed into strain ALF3 to create ALF82. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
-</item>
-<item id="5_78" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275474"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_63"/></collection>
-</item>
-<item id="4_101" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00019620"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_80"/><reference ref_id="3_81"/><reference ref_id="3_82"/></collection>
-</item>
-<item id="5_53" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar02141399"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_46"/></collection>
-</item>
-<item id="5_90" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00241522"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
-</item>
-<item id="4_76" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00005039"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_62"/></collection>
-</item>
-<item id="4_73" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00003043"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_61"/><reference ref_id="3_65"/></collection>
-</item>
-<item id="3_94" class="Strain">
+<item id="3_96" class="Strain">
 <attribute name="CGCReceived" value="2005-04-05"/>
-<attribute name="genotype" value="rmIs126."/>
+<attribute name="genotype" value="rmIs132 I."/>
 <attribute name="laboratory" value="CGC"/>
 <attribute name="mutagen" value="Gamma Rays"/>
 <attribute name="outcrossed" value="x5"/>
-<attribute name="primaryIdentifier" value="AM134"/>
-<attribute name="remark" value="rmIs126 [unc-54p::Q0::YFP]. Diffuse distribution of Q0::YFP throughout the body-wall muscle cells. [NOTE: (04/29/13) Strain is reported as incorrect -- apparently carries 20Q transgene. Working on obtaining a replacement.]"/>
+<attribute name="primaryIdentifier" value="AM140"/>
+<attribute name="remark" value="rmIs132 [unc-54p::Q35::YFP]. AM140 animals show a Q35::YFP progressive transition from soluble to aggregated as they age."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_120"/></collection>
+<collection name="genes"><reference ref_id="4_85"/></collection>
 </item>
-<item id="4_11" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00002004"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<item id="3_47" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="otIs225 II; daf-18(ok480) IV; armEx218."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson9913"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK573"/>
+<attribute name="remark" value="otIs225 [cat-4::GFP] II. armEx218 [unc-119p::daf-18 + unc-119p::tagRFP + rol-6(su1006)]. Pick Rollers to maintain. Transgenic array expresses DAF-18 from unc-119 pan-neuronal promoter; rescues the HSN undermigration phenotype in daf-18 null mutants. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_10"/></collection>
+<collection name="genes"><reference ref_id="4_30"/></collection>
+<collection name="variations"><reference ref_id="5_30"/></collection>
 </item>
 <item id="0_1" class="Ontology">
 <attribute name="name" value="Sequence Ontology"/>
@@ -168,102 +125,67 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_50" class="Strain">
-<attribute name="CGCReceived" value="2013-12-16"/>
-<attribute name="genotype" value="daf-16(mu86) I; zdIs13 IV; armEx257."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson9913"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK650"/>
-<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx257 [dpy-7p::daf-16b::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx257 rescues the daf-16(mu86) HSN undermigration phenotype. dpy-7p::daf-16b::tagRFP expression is localized to nuclei in hypodermal tissue during the comma, 1.5 and 2-fold stages, becoming cytoplasmic or perinuclear by the 3-fold stage and persisting into adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_32"/></collection>
-<collection name="variations"><reference ref_id="5_31"/></collection>
-</item>
-<item id="4_91" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00000908"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
-</item>
-<item id="3_60" class="Strain">
-<attribute name="CGCReceived" value="2001-05-21"/>
-<attribute name="genotype" value="lip-1(zh15) IV."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson2597"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x8"/>
-<attribute name="primaryIdentifier" value="AH102"/>
-<attribute name="remark" value="Deletion allele which removes exons 2 to 6 of lip-1 (C05B10.1). Incompletely penetrant ovulation defect."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_73"/></collection>
-<collection name="variations"><reference ref_id="5_73"/></collection>
-</item>
-<item id="3_45" class="Strain">
-<attribute name="genotype" value="unc-119(ed3) III; armEx199."/>
+<item id="3_36" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx53."/>
 <attribute name="laboratory" value="CGC"/>
 <attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK537"/>
-<attribute name="remark" value="armEx199 [cdl-1p::cdl-1::GFP + unc-119(+)]. Pick non-Unc to maintain. Nuclear localization of CDL-1::GFP in the germline and early embryos; strong enrichement of CDL-1::GFP in the nuclei of developing oocytes. Reference: Avgousti DC, et al. EMBO J. 2012 Oct 3;31(19):3821-32."/>
+<attribute name="primaryIdentifier" value="AGK234"/>
+<attribute name="remark" value="armEx53 [WRM0611aH08 + unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. This strain contains a transgenic array that expresses the WRM0611aH08 fosmid construct. This fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. Expression of this fosmid construct in JU258 worms restores the expression of the missing 21U-RNAs in the germline, as measured by RT-qPCR. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
 </item>
-<item id="3_88" class="Strain">
-<attribute name="CGCReceived" value="2004-10-14"/>
-<attribute name="genotype" value="osr-1(rm1) I."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson3909"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x4"/>
-<attribute name="primaryIdentifier" value="AM1"/>
-<attribute name="remark" value="Osmotic stress resistant. Received new stock May 7, 2008."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_112"/></collection>
-<collection name="variations"><reference ref_id="5_111"/></collection>
-</item>
-<item id="4_44" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00006975"/>
+<item id="4_32" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00003911"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
+<collection name="strains"><reference ref_id="3_49"/></collection>
 </item>
-<item id="3_80" class="Strain">
-<attribute name="laboratory" value="ALF"/>
-<attribute name="primaryIdentifier" value="ALF100"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="4_14" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000912"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_101"/></collection>
+<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
 </item>
-<item id="3_58" class="Strain">
-<attribute name="CGCReceived" value="1997-12-08"/>
-<attribute name="genotype" value="gap-1(ga133) X."/>
+<item id="4_2" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002004"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_10"/></collection>
+</item>
+<item id="3_72" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs4."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson232"/>
-<attribute name="mutagen" value="Psoralen"/>
-<attribute name="outcrossed" value="x4"/>
-<attribute name="primaryIdentifier" value="AH12"/>
-<attribute name="remark" value="Null allele."/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF4"/>
+<attribute name="remark" value="bafIs4 [daf-12 fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_68"/></collection>
-<collection name="variations"><reference ref_id="5_68"/></collection>
+<collection name="genes"><reference ref_id="4_62"/><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/><reference ref_id="5_59"/><reference ref_id="5_61"/></collection>
 </item>
-<item id="3_96" class="Strain">
-<attribute name="CGCReceived" value="2005-04-05"/>
-<attribute name="genotype" value="rmIs132 I."/>
+<item id="5_35" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00145428"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
+</item>
+<item id="3_26" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="glp-1(e2141) III; uthEx649."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="mutagen" value="Gamma Rays"/>
-<attribute name="outcrossed" value="x5"/>
-<attribute name="primaryIdentifier" value="AM140"/>
-<attribute name="remark" value="rmIs132 [unc-54p::Q35::YFP]. AM140 animals show a Q35::YFP progressive transition from soluble to aggregated as they age."/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1047"/>
+<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_120"/></collection>
+<collection name="genes"><reference ref_id="4_10"/></collection>
+<collection name="variations"><reference ref_id="5_8"/></collection>
 </item>
 <item id="3_40" class="Strain">
 <attribute name="primaryIdentifier" value="AGK339"/>
@@ -274,30 +196,18 @@
 <reference name="ontology" ref_id="0_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="5_111" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00241620"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_88"/></collection>
-</item>
-<item id="5_71" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00143722"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_59"/></collection>
-</item>
-<item id="3_18" class="Strain">
-<attribute name="CGCReceived" value="2013-11-22"/>
-<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx557."/>
+<item id="3_71" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson18908"/>
-<attribute name="outcrossed" value="x"/>
-<attribute name="primaryIdentifier" value="AGD886"/>
-<attribute name="remark" value="uthEx557 [sur-5p::rpn-6 + myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF3"/>
+<attribute name="remark" value="Daf-d. Unc."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_19"/><reference ref_id="4_20"/></collection>
-<collection name="variations"><reference ref_id="5_18"/><reference ref_id="5_19"/></collection>
+<collection name="genes"><reference ref_id="4_62"/><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/><reference ref_id="5_59"/><reference ref_id="5_61"/></collection>
 </item>
 <item id="3_95" class="Strain">
 <attribute name="CGCReceived" value="2005-04-05"/>
@@ -310,11 +220,20 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="5_35" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00145093"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<item id="4_49" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002297"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
+<collection name="strains"><reference ref_id="3_64"/></collection>
+</item>
+<item id="3_84" class="Strain">
+<attribute name="genotype" value="hgo-1(baf2) I."/>
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF104"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_78"/></collection>
+<collection name="variations"><reference ref_id="5_75"/></collection>
 </item>
 <item id="3_29" class="Strain">
 <attribute name="CGCReceived" value="2015-05-28"/>
@@ -327,19 +246,37 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_63" class="Strain">
-<attribute name="CGCReceived" value="2005-10-26"/>
-<attribute name="genotype" value="sdn-1(zh20) X."/>
+<item id="3_94" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs126."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson3021"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x6"/>
-<attribute name="primaryIdentifier" value="AH205"/>
-<attribute name="remark" value="Slightly Unc. Variably Egl. zh20 is a deletion in sdn-1. The sequence of the breakpoint is: TTTGCTTCACAC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM134"/>
+<attribute name="remark" value="rmIs126 [unc-54p::Q0::YFP]. Diffuse distribution of Q0::YFP throughout the body-wall muscle cells. [NOTE: (04/29/13) Strain is reported as incorrect -- apparently carries 20Q transgene. Working on obtaining a replacement.]"/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_78"/></collection>
-<collection name="variations"><reference ref_id="5_78"/></collection>
+<collection name="genes"><reference ref_id="4_85"/></collection>
+</item>
+<item id="4_35" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001515"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
+</item>
+<item id="3_59" class="Strain">
+<attribute name="CGCReceived" value="2000-07-24"/>
+<attribute name="genotype" value="apr-1(zh10) unc-29(e1072) I; zhEx11."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson232"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x6"/>
+<attribute name="primaryIdentifier" value="AH75"/>
+<attribute name="remark" value="zhEx11[apr-1(+) + sur-5::GFP]. Unc. Segregates dead eggs that have lost the rescuing array."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_37"/><reference ref_id="4_39"/></collection>
+<collection name="variations"><reference ref_id="5_37"/><reference ref_id="5_39"/></collection>
 </item>
 <item id="6_1" class="SOTerm">
 <attribute name="name" value="gene"/>
@@ -361,65 +298,54 @@
 <attribute name="primaryIdentifier" value="AM470"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_43" class="Strain">
-<attribute name="CGCReceived" value="2013-11-20"/>
-<attribute name="genotype" value="zfp-1(ok554) III; armIs9."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x2"/>
-<attribute name="primaryIdentifier" value="AGK370"/>
-<attribute name="remark" value="armIs9 [zfp-1(long isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs9 transgene rescues zfp-1(ok554)/nDf17 lethality. Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_44"/></collection>
-<collection name="variations"><reference ref_id="5_43"/></collection>
-</item>
-<item id="3_93" class="Strain">
-<attribute name="laboratory" value="AM"/>
-<attribute name="primaryIdentifier" value="AM102"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_117"/></collection>
-</item>
-<item id="4_70" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00000156"/>
+<item id="4_46" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00004749"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_59"/></collection>
+<collection name="strains"><reference ref_id="3_63"/></collection>
 </item>
-<item id="3_26" class="Strain">
-<attribute name="CGCReceived" value="2014-04-25"/>
-<attribute name="genotype" value="glp-1(e2141) III; uthEx649."/>
+<item id="3_49" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="zdIs13 IV; pak-1(ok448) X; armEx252."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="madeBy" value="WBPerson9913"/>
 <attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGD1047"/>
-<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="primaryIdentifier" value="AGK640"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx252 [dpy-7p::pak-1::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx252 rescues the pak-1(ok480) HSN undermigration phenotype. pak-1::tagRFP is expressed in the hypodermal tissue throughout development and adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_28"/></collection>
-<collection name="variations"><reference ref_id="5_27"/></collection>
+<collection name="genes"><reference ref_id="4_32"/></collection>
+<collection name="variations"><reference ref_id="5_32"/></collection>
 </item>
-<item id="4_28" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00001609"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<item id="5_12" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00089216"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
+<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
 </item>
-<item id="3_37" class="Strain">
-<attribute name="CGCReceived" value="2013-11-20"/>
-<attribute name="genotype" value="zfp-1(ok554) unc-119(ed3) III; armEx14."/>
+<item id="3_92" class="Strain">
+<attribute name="CGCReceived" value="2011-01-06"/>
+<attribute name="genotype" value="rmIs110."/>
 <attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3267"/>
+<attribute name="mutagen" value="Gamma irradiation"/>
 <attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK280"/>
-<attribute name="remark" value="armEx14 [PHD1-PHD2::FLAG + zfp-1(short isoform) + unc-119(+)]. Pick non-Unc animals to maintain. The fosmid-based armEx14 transgene rescues zfp-1(ok554)/nDf17 lethality. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="primaryIdentifier" value="AM101"/>
+<attribute name="remark" value="rmIs110 [F25B3.3p::Q40::YFP]. Pan-neuronal YFP expression. Reference: Gidalevitz T, et al., Science. 2006 Mar 10;311(5766):1471-4."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/><reference ref_id="4_44"/></collection>
-<collection name="variations"><reference ref_id="5_43"/><reference ref_id="5_35"/></collection>
+<collection name="genes"><reference ref_id="4_82"/></collection>
 </item>
 <item id="3_77" class="Strain">
 <attribute name="primaryIdentifier" value="ALF72"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_82" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF102"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_72"/></collection>
 </item>
 <item id="3_51" class="Strain">
 <attribute name="primaryIdentifier" value="AGK688"/>
@@ -437,42 +363,79 @@
 <attribute name="primaryIdentifier" value="AGD638"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_68" class="Strain">
-<attribute name="laboratory" value="AK"/>
-<attribute name="primaryIdentifier" value="AK100"/>
+<item id="5_47" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00142975"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_35" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx58."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK233"/>
+<attribute name="remark" value="armEx58 [WRM0611aH08-Del8mer + unc-119(+)]. Pick non-Unc to maintain. This strain contains a transgenic array that expresses a derivative WRM0611aH08 fosmid. The WRM0611aH08 fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. This derivative fosmid construct lacks the upstream 8-mer motif (CTGTTTCA) next to 21U-3372. The expression of this individual 21U-RNA is lost in transgenic animals. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_87"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
+</item>
+<item id="3_78" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs62."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson14558"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF82"/>
+<attribute name="remark" value="bafIs62 [lin-42p::GFP + unc-119(+)]. lin-42p::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+). Array was crossed into strain ALF3 to create ALF82. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_62"/><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/><reference ref_id="5_59"/><reference ref_id="5_61"/></collection>
 </item>
 <item id="3_99" class="Strain">
 <attribute name="primaryIdentifier" value="AM265"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_46" class="Strain">
-<attribute name="CGCReceived" value="2014-12-16"/>
-<attribute name="genotype" value="armSi1 II; unc-119(ed3) III."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson10009"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK541"/>
-<attribute name="remark" value="armSi1 [mex5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)] II. GFP expression from transgene is observed in the germline. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="5_2" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000354"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_53"/><reference ref_id="5_35"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
 </item>
-<item id="3_62" class="Strain">
-<attribute name="CGCReceived" value="2003-12-16"/>
-<attribute name="genotype" value="sra-13(zh13) II."/>
+<item id="3_18" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx557."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x8"/>
-<attribute name="primaryIdentifier" value="AH159"/>
-<attribute name="remark" value="sra-13(zh13) mutants display stronger chemotaxis to limiting concentrations of isoamylalcohol and diacetyl than WT animals. Deletion allele. 396 bp of 5' promoter sequence and all but the last exon are removed; probably a null allele."/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD886"/>
+<attribute name="remark" value="uthEx557 [sur-5p::rpn-6 + myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_76"/></collection>
-<collection name="variations"><reference ref_id="5_76"/></collection>
+<collection name="genes"><reference ref_id="4_4"/><reference ref_id="4_6"/></collection>
+<collection name="variations"><reference ref_id="5_2"/><reference ref_id="5_4"/></collection>
+</item>
+<item id="3_81" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF101"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_72"/></collection>
+</item>
+<item id="3_25" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="glp-1(e2141) III; xzEx3."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1033"/>
+<attribute name="remark" value="xzEx3 [unc-54p::UbG76V::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_10"/></collection>
+<collection name="variations"><reference ref_id="5_8"/></collection>
 </item>
 <item id="3_13" class="Strain">
 <attribute name="CGCReceived" value="2013-09-18"/>
@@ -485,41 +448,35 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="5_91" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00241609"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
-</item>
-<item id="3_36" class="Strain">
-<attribute name="CGCReceived" value="2014-12-16"/>
-<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx53."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK234"/>
-<attribute name="remark" value="armEx53 [WRM0611aH08 + unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. This strain contains a transgenic array that expresses the WRM0611aH08 fosmid construct. This fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. Expression of this fosmid construct in JU258 worms restores the expression of the missing 21U-RNAs in the germline, as measured by RT-qPCR. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="5_27" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00144590"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
-</item>
-<item id="5_104" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00000435"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_83"/></collection>
-</item>
-<item id="4_117" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00009100"/>
+<item id="4_78" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001843"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_92"/><reference ref_id="3_93"/></collection>
+<collection name="strains"><reference ref_id="3_84"/></collection>
+</item>
+<item id="3_45" class="Strain">
+<attribute name="genotype" value="unc-119(ed3) III; armEx199."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK537"/>
+<attribute name="remark" value="armEx199 [cdl-1p::cdl-1::GFP + unc-119(+)]. Pick non-Unc to maintain. Nuclear localization of CDL-1::GFP in the germline and early embryos; strong enrichement of CDL-1::GFP in the nuclei of developing oocytes. Reference: Avgousti DC, et al. EMBO J. 2012 Oct 3;31(19):3821-32."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
+</item>
+<item id="3_75" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; bafIs63."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson14558"/>
+<attribute name="outcrossed" value="x1"/>
+<attribute name="primaryIdentifier" value="ALF63"/>
+<attribute name="remark" value="bafIs63 [lin-42p(mut)::GFP + unc-119(+)]. lin-42p(mut)::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+); all potential DAF-12 binding sites have been mutated. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
 </item>
 <item id="3_33" class="Strain">
 <attribute name="primaryIdentifier" value="AGK128"/>
@@ -536,35 +493,59 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="4_23" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006975"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
+</item>
 <item id="3_86" class="Strain">
 <attribute name="primaryIdentifier" value="ALF115"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="4_17" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006843"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="4_30" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000913"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_47"/></collection>
+</item>
+<item id="5_32" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091739"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_49"/></collection>
+</item>
+<item id="3_93" class="Strain">
+<attribute name="laboratory" value="AM"/>
+<attribute name="primaryIdentifier" value="AM102"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_82"/></collection>
+</item>
+<item id="5_41" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275471"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_65"/></collection>
+</item>
 <item id="1_1" class="DataSource">
 <attribute name="name" value="AceDB XML"/>
 </item>
-<item id="3_92" class="Strain">
-<attribute name="CGCReceived" value="2011-01-06"/>
-<attribute name="genotype" value="rmIs110."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson3267"/>
-<attribute name="mutagen" value="Gamma irradiation"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AM101"/>
-<attribute name="remark" value="rmIs110 [F25B3.3p::Q40::YFP]. Pan-neuronal YFP expression. Reference: Gidalevitz T, et al., Science. 2006 Mar 10;311(5766):1471-4."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="5_8" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00144590"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_117"/></collection>
+<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
 </item>
 <item id="3_28" class="Strain">
 <attribute name="primaryIdentifier" value="AGD1079"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="5_70" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275469"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_59"/></collection>
 </item>
 <item id="3_19" class="Strain">
 <attribute name="primaryIdentifier" value="AGD925"/>
@@ -594,44 +575,23 @@
 <attribute name="primaryIdentifier" value="AGK336"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_30" class="Strain">
-<attribute name="CGCReceived" value="2013-11-20"/>
-<attribute name="genotype" value="unc-119(ed3) III; armEx5."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK26"/>
-<attribute name="remark" value="armEx5 [zfp-1(fosmid)::GFP + unc-119(+)]. Pick non-Unc to maintain. Fosmid-based zfp-1::GFP transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. Nuclear expression of zfp-1::GFP is observed ubiquitously in somatic cells in all developmental stages; high levels of GFP expression is observed in oocytes with lower levels of expression in the distal germline. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="4_41" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00003043"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
+<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_61"/><reference ref_id="3_65"/></collection>
 </item>
-<item id="3_64" class="Strain">
-<attribute name="CGCReceived" value="2005-12-27"/>
-<attribute name="genotype" value="unc-4(e120) ect-2(zh8) II; gap-1(ga133) X."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson3021"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x3"/>
-<attribute name="primaryIdentifier" value="AH286"/>
-<attribute name="remark" value="Muv and Unc. Semi-dominant mutation in ect-2 (previously called let-21)."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="5_15" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00145093"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_68"/><reference ref_id="4_80"/><reference ref_id="4_81"/></collection>
-<collection name="variations"><reference ref_id="5_80"/><reference ref_id="5_81"/><reference ref_id="5_68"/></collection>
+<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
 </item>
-<item id="3_61" class="Strain">
-<attribute name="CGCReceived" value="2001-05-21"/>
-<attribute name="genotype" value="zhIs4 III."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson2597"/>
-<attribute name="mutagen" value="Gamma Rays"/>
-<attribute name="outcrossed" value="x5"/>
-<attribute name="primaryIdentifier" value="AH142"/>
-<attribute name="remark" value="zhIs4 [lip-1::GFP] III. lip-1::GFP transcriptional reporter expression is upregulated in the secondary VPCs P5.p and P7.p of early L3 animals."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="4_62" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000908"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_73"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
 </item>
 <item id="3_12" class="Strain">
 <attribute name="CGCReceived" value="2013-11-22"/>
@@ -644,18 +604,11 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_67" class="Strain">
-<attribute name="CGCReceived" value="2016-02-18"/>
-<attribute name="genotype" value="unc-119(ed3) III; zhIs38 IV."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="mutagen" value="Bombardment"/>
-<attribute name="outcrossed" value="x2"/>
-<attribute name="primaryIdentifier" value="AH1779"/>
-<attribute name="remark" value="zhIs38 [let-23::GFP + unc-119(+)] IV. zhIs38 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene is expressed at levels similar to endogenous LET-23. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="5_27" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar02141399"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
+<collection name="strains"><reference ref_id="3_46"/></collection>
 </item>
 <item id="3_31" class="Strain">
 <attribute name="primaryIdentifier" value="AGK29"/>
@@ -664,19 +617,6 @@
 <item id="2_1" class="DataSet">
 <attribute name="name" value="WormBaseAcedbConverter"/>
 <reference name="dataSource" ref_id="1_1"/>
-</item>
-<item id="3_17" class="Strain">
-<attribute name="CGCReceived" value="2013-09-18"/>
-<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx633."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson18908"/>
-<attribute name="outcrossed" value="x"/>
-<attribute name="primaryIdentifier" value="AGD885"/>
-<attribute name="remark" value="uthEx633 [myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_19"/><reference ref_id="4_20"/></collection>
-<collection name="variations"><reference ref_id="5_18"/><reference ref_id="5_19"/></collection>
 </item>
 <item id="3_4" class="Strain">
 <attribute name="CGCReceived" value="2013-09-18"/>
@@ -689,96 +629,38 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="5_59" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241522"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
+</item>
 <item id="3_70" class="Strain">
 <attribute name="primaryIdentifier" value="AL132"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_34" class="Strain">
-<attribute name="CGCReceived" value="2013-11-20"/>
-<attribute name="genotype" value="unc-119(ed3) III; zdIs13 IV; armIs5."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK192"/>
-<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armIs5 [zfp-1(fosmid)::FLAG + unc-119(+)]. Integrated zfp-1 transgene expressed in the germline. Fosmid-based zfp-1::FLAG transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. ChIP with anti-FLAG antibody detects ZFP-1::FLAG localization to promoters of highly expressed genes. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015. Cecere G, et al. Mol Cell. 2013 Jun 27;50(6):894-907."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
+<item id="4_39" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006765"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="5_106" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00000436"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_84"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
 </item>
 <item id="3_41" class="Strain">
 <attribute name="primaryIdentifier" value="AGK343"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_20" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00004510"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
-</item>
-<item id="3_73" class="Strain">
-<attribute name="CGCReceived" value="2012-05-01"/>
-<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs9."/>
+<item id="3_61" class="Strain">
+<attribute name="CGCReceived" value="2001-05-21"/>
+<attribute name="genotype" value="zhIs4 III."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson4598"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="ALF9"/>
-<attribute name="remark" value="bafIs9 [daf-12::TAP fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. TAP tag insertedinto daf-12 fosmid. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="madeBy" value="WBPerson2597"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AH142"/>
+<attribute name="remark" value="zhIs4 [lip-1::GFP] III. lip-1::GFP transcriptional reporter expression is upregulated in the secondary VPCs P5.p and P7.p of early L3 animals."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
-</item>
-<item id="5_18" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00000354"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
-</item>
-<item id="3_84" class="Strain">
-<attribute name="genotype" value="hgo-1(baf2) I."/>
-<attribute name="laboratory" value="ALF"/>
-<attribute name="primaryIdentifier" value="ALF104"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_107"/></collection>
-<collection name="variations"><reference ref_id="5_106"/></collection>
-</item>
-<item id="3_42" class="Strain">
-<attribute name="CGCReceived" value="2014-12-16"/>
-<attribute name="genotype" value="zfp-1(ok554) III; armIs8."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x"/>
-<attribute name="primaryIdentifier" value="AGK369"/>
-<attribute name="remark" value="armIs8 [zfp-1(short isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs8 transgene rescues the protruded vulva phenotype of zfp-1(ok554). Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_44"/></collection>
-<collection name="variations"><reference ref_id="5_43"/></collection>
-</item>
-<item id="3_35" class="Strain">
-<attribute name="CGCReceived" value="2014-12-16"/>
-<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx58."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK233"/>
-<attribute name="remark" value="armEx58 [WRM0611aH08-Del8mer + unc-119(+)]. Pick non-Unc to maintain. This strain contains a transgenic array that expresses a derivative WRM0611aH08 fosmid. The WRM0611aH08 fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. This derivative fosmid construct lacks the upstream 8-mer motif (CTGTTTCA) next to 21U-3372. The expression of this individual 21U-RNA is lost in transgenic animals. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="3_69" class="Strain">
-<attribute name="laboratory" value="AK"/>
-<attribute name="primaryIdentifier" value="AK103"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_87"/></collection>
+<collection name="genes"><reference ref_id="4_41"/></collection>
 </item>
 <item id="3_38" class="Strain">
 <attribute name="primaryIdentifier" value="AGK335"/>
@@ -799,11 +681,12 @@
 <attribute name="primaryIdentifier" value="AGK690"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_120" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00006789"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<item id="3_68" class="Strain">
+<attribute name="laboratory" value="AK"/>
+<attribute name="primaryIdentifier" value="AK100"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_94"/><reference ref_id="3_96"/><reference ref_id="3_97"/></collection>
+<collection name="genes"><reference ref_id="4_59"/></collection>
 </item>
 <item id="3_20" class="Strain">
 <attribute name="CGCReceived" value="2015-05-28"/>
@@ -827,35 +710,6 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_59" class="Strain">
-<attribute name="CGCReceived" value="2000-07-24"/>
-<attribute name="genotype" value="apr-1(zh10) unc-29(e1072) I; zhEx11."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson232"/>
-<attribute name="mutagen" value="EMS"/>
-<attribute name="outcrossed" value="x6"/>
-<attribute name="primaryIdentifier" value="AH75"/>
-<attribute name="remark" value="zhEx11[apr-1(+) + sur-5::GFP]. Unc. Segregates dead eggs that have lost the rescuing array."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_70"/><reference ref_id="4_71"/></collection>
-<collection name="variations"><reference ref_id="5_70"/><reference ref_id="5_71"/></collection>
-</item>
-<item id="3_83" class="Strain">
-<attribute name="genotype" value="F42D1.2(baf1) X."/>
-<attribute name="laboratory" value="ALF"/>
-<attribute name="primaryIdentifier" value="ALF103"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_105"/></collection>
-<collection name="variations"><reference ref_id="5_104"/></collection>
-</item>
-<item id="4_68" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00001515"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
-</item>
 <item id="3_15" class="Strain">
 <attribute name="CGCReceived" value="2013-09-18"/>
 <attribute name="genotype" value="rmIs110; uthEx633."/>
@@ -867,7 +721,20 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_19" class="Gene">
+<item id="3_73" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs9."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF9"/>
+<attribute name="remark" value="bafIs9 [daf-12::TAP fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. TAP tag insertedinto daf-12 fosmid. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_62"/><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/><reference ref_id="5_59"/><reference ref_id="5_61"/></collection>
+</item>
+<item id="4_4" class="Gene">
 <attribute name="primaryIdentifier" value="WBGene00001411"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -877,129 +744,173 @@
 <attribute name="primaryIdentifier" value="AGK689"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_78" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00004749"/>
+<item id="5_43" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275470"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_62"/></collection>
+</item>
+<item id="3_66" class="Strain">
+<attribute name="CGCReceived" value="2016-02-18"/>
+<attribute name="genotype" value="unc-119(ed3) III; zhIs35 I."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Bombardment"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AH1747"/>
+<attribute name="remark" value="zhIs35 [let-23::GFP + unc-119(+)] I. zhIs35 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene expression is higher in this strain than in AH1779 unc-119(ed3) III; zhIs38. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
+</item>
+<item id="3_97" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs133."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM141"/>
+<attribute name="remark" value="rmIs133 [unc-54p::Q40::YFP]. AM141 animals show a soluble Q40::YFP distribution in body wall muscle cells immediately after hatching. As these worms age the rapid formation of foci is observed. When they reach adulthood, AM141 animals show an entirely Q40::YFP aggregated phenotype."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_85"/></collection>
+</item>
+<item id="3_30" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="unc-119(ed3) III; armEx5."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK26"/>
+<attribute name="remark" value="armEx5 [zfp-1(fosmid)::GFP + unc-119(+)]. Pick non-Unc to maintain. Fosmid-based zfp-1::GFP transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. Nuclear expression of zfp-1::GFP is observed ubiquitously in somatic cells in all developmental stages; high levels of GFP expression is observed in oocytes with lower levels of expression in the distal germline. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
+</item>
+<item id="3_58" class="Strain">
+<attribute name="CGCReceived" value="1997-12-08"/>
+<attribute name="genotype" value="gap-1(ga133) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson232"/>
+<attribute name="mutagen" value="Psoralen"/>
+<attribute name="outcrossed" value="x4"/>
+<attribute name="primaryIdentifier" value="AH12"/>
+<attribute name="remark" value="Null allele."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_35"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="5_73" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000435"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_83"/></collection>
+</item>
+<item id="4_10" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001609"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
+</item>
+<item id="3_27" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="daf-16(mu86) I; glp-1(e2141) III; uthEx649."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1048"/>
+<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_14"/><reference ref_id="4_10"/></collection>
+<collection name="variations"><reference ref_id="5_12"/><reference ref_id="5_8"/></collection>
+</item>
+<item id="3_60" class="Strain">
+<attribute name="CGCReceived" value="2001-05-21"/>
+<attribute name="genotype" value="lip-1(zh15) IV."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson2597"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x8"/>
+<attribute name="primaryIdentifier" value="AH102"/>
+<attribute name="remark" value="Deletion allele which removes exons 2 to 6 of lip-1 (C05B10.1). Incompletely penetrant ovulation defect."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_41"/></collection>
+<collection name="variations"><reference ref_id="5_41"/></collection>
+</item>
+<item id="5_45" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275474"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 <collection name="strains"><reference ref_id="3_63"/></collection>
 </item>
-<item id="4_58" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00003911"/>
+<item id="4_76" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009628"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_49"/></collection>
+<collection name="strains"><reference ref_id="3_83"/></collection>
 </item>
-<item id="5_83" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275477"/>
+<item id="5_30" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091768"/>
 <reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_65"/></collection>
-</item>
-<item id="3_47" class="Strain">
-<attribute name="CGCReceived" value="2013-12-16"/>
-<attribute name="genotype" value="otIs225 II; daf-18(ok480) IV; armEx218."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson9913"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK573"/>
-<attribute name="remark" value="otIs225 [cat-4::GFP] II. armEx218 [unc-119p::daf-18 + unc-119p::tagRFP + rol-6(su1006)]. Pick Rollers to maintain. Transgenic array expresses DAF-18 from unc-119 pan-neuronal promoter; rescues the HSN undermigration phenotype in daf-18 null mutants. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_55"/></collection>
-<collection name="variations"><reference ref_id="5_55"/></collection>
-</item>
-<item id="3_44" class="Strain">
-<attribute name="CGCReceived" value="2014-12-16"/>
-<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx196."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson10009"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK532"/>
-<attribute name="remark" value="armEx196 [mex-5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to deletion of the niDF199 locus. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="3_75" class="Strain">
-<attribute name="CGCReceived" value="2012-05-01"/>
-<attribute name="genotype" value="unc-119(ed3) III; bafIs63."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson14558"/>
-<attribute name="outcrossed" value="x1"/>
-<attribute name="primaryIdentifier" value="ALF63"/>
-<attribute name="remark" value="bafIs63 [lin-42p(mut)::GFP + unc-119(+)]. lin-42p(mut)::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+); all potential DAF-12 binding sites have been mutated. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="4_36" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00006843"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
-</item>
-<item id="4_55" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00000913"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 <collection name="strains"><reference ref_id="3_47"/></collection>
-</item>
-<item id="4_80" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00002297"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_64"/></collection>
-</item>
-<item id="3_82" class="Strain">
-<attribute name="laboratory" value="ALF"/>
-<attribute name="primaryIdentifier" value="ALF102"/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_101"/></collection>
-</item>
-<item id="4_81" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00006744"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
-</item>
-<item id="5_58" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00091739"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_49"/></collection>
-</item>
-<item id="5_80" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00142975"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
 </item>
 <item id="3_1" class="Strain">
 <attribute name="primaryIdentifier" value="AGD568"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_25" class="Strain">
+<item id="4_44" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00005039"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_62"/></collection>
+</item>
+<item id="4_85" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006789"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_94"/><reference ref_id="3_96"/><reference ref_id="3_97"/></collection>
+</item>
+<item id="3_24" class="Strain">
 <attribute name="CGCReceived" value="2013-11-22"/>
-<attribute name="genotype" value="glp-1(e2141) III; xzEx3."/>
+<attribute name="genotype" value="glp-1(e2141) III; xzEx1."/>
 <attribute name="laboratory" value="CGC"/>
 <attribute name="madeBy" value="WBPerson18908"/>
 <attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGD1033"/>
-<attribute name="remark" value="xzEx3 [unc-54p::UbG76V::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="primaryIdentifier" value="AGD1032"/>
+<attribute name="remark" value="xzEx1 [unc-54p::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_28"/></collection>
-<collection name="variations"><reference ref_id="5_27"/></collection>
+<collection name="genes"><reference ref_id="4_10"/></collection>
+<collection name="variations"><reference ref_id="5_8"/></collection>
 </item>
-<item id="3_81" class="Strain">
-<attribute name="laboratory" value="ALF"/>
-<attribute name="primaryIdentifier" value="ALF101"/>
+<item id="3_67" class="Strain">
+<attribute name="CGCReceived" value="2016-02-18"/>
+<attribute name="genotype" value="unc-119(ed3) III; zhIs38 IV."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Bombardment"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AH1779"/>
+<attribute name="remark" value="zhIs38 [let-23::GFP + unc-119(+)] IV. zhIs38 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene is expressed at levels similar to endogenous LET-23. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_101"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
+</item>
+<item id="5_39" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00143722"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="5_4" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00087750"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
 </item>
 <item id="3_74" class="Strain">
 <attribute name="CGCReceived" value="2012-05-01"/>
@@ -1013,65 +924,46 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_49" class="Strain">
-<attribute name="CGCReceived" value="2013-12-16"/>
-<attribute name="genotype" value="zdIs13 IV; pak-1(ok448) X; armEx252."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson9913"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGK640"/>
-<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx252 [dpy-7p::pak-1::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx252 rescues the pak-1(ok480) HSN undermigration phenotype. pak-1::tagRFP is expressed in the hypodermal tissue throughout development and adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_58"/></collection>
-<collection name="variations"><reference ref_id="5_58"/></collection>
-</item>
-<item id="4_105" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00009628"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_83"/></collection>
-</item>
 <item id="3_55" class="Strain">
 <attribute name="primaryIdentifier" value="AGK711"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_24" class="Strain">
-<attribute name="CGCReceived" value="2013-11-22"/>
-<attribute name="genotype" value="glp-1(e2141) III; xzEx1."/>
+<item id="4_72" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00019620"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_80"/><reference ref_id="3_81"/><reference ref_id="3_82"/></collection>
+</item>
+<item id="5_52" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275477"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_17" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx633."/>
 <attribute name="laboratory" value="CGC"/>
 <attribute name="madeBy" value="WBPerson18908"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="AGD1032"/>
-<attribute name="remark" value="xzEx1 [unc-54p::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD885"/>
+<attribute name="remark" value="uthEx633 [myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_28"/></collection>
-<collection name="variations"><reference ref_id="5_27"/></collection>
+<collection name="genes"><reference ref_id="4_4"/><reference ref_id="4_6"/></collection>
+<collection name="variations"><reference ref_id="5_2"/><reference ref_id="5_4"/></collection>
 </item>
-<item id="3_97" class="Strain">
-<attribute name="CGCReceived" value="2005-04-05"/>
-<attribute name="genotype" value="rmIs133."/>
+<item id="3_34" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="unc-119(ed3) III; zdIs13 IV; armIs5."/>
 <attribute name="laboratory" value="CGC"/>
-<attribute name="mutagen" value="Gamma Rays"/>
-<attribute name="outcrossed" value="x5"/>
-<attribute name="primaryIdentifier" value="AM141"/>
-<attribute name="remark" value="rmIs133 [unc-54p::Q40::YFP]. AM141 animals show a soluble Q40::YFP distribution in body wall muscle cells immediately after hatching. As these worms age the rapid formation of foci is observed. When they reach adulthood, AM141 animals show an entirely Q40::YFP aggregated phenotype."/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK192"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armIs5 [zfp-1(fosmid)::FLAG + unc-119(+)]. Integrated zfp-1 transgene expressed in the germline. Fosmid-based zfp-1::FLAG transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. ChIP with anti-FLAG antibody detects ZFP-1::FLAG localization to promoters of highly expressed genes. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015. Cecere G, et al. Mol Cell. 2013 Jun 27;50(6):894-907."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_120"/></collection>
-</item>
-<item id="5_68" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00145428"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
-</item>
-<item id="5_73" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275471"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_65"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
 </item>
 <item id="3_65" class="Strain">
 <attribute name="CGCReceived" value="2005-12-27"/>
@@ -1083,8 +975,15 @@
 <attribute name="remark" value="Pvl and weak Muv. Transformation of secondary to primary vulval cell fates."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_73"/><reference ref_id="4_81"/><reference ref_id="4_83"/></collection>
-<collection name="variations"><reference ref_id="5_83"/><reference ref_id="5_80"/><reference ref_id="5_73"/></collection>
+<collection name="genes"><reference ref_id="4_41"/><reference ref_id="4_51"/><reference ref_id="4_55"/></collection>
+<collection name="variations"><reference ref_id="5_52"/><reference ref_id="5_47"/><reference ref_id="5_41"/></collection>
+</item>
+<item id="3_80" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF100"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_72"/></collection>
 </item>
 <item id="3_85" class="Strain">
 <attribute name="primaryIdentifier" value="ALF110"/>
@@ -1093,12 +992,6 @@
 <item id="3_11" class="Strain">
 <attribute name="primaryIdentifier" value="AGD803"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-</item>
-<item id="5_43" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00091841"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
 </item>
 <item id="3_7" class="Strain">
 <attribute name="CGCReceived" value="2015-05-29"/>
@@ -1111,15 +1004,54 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="3_64" class="Strain">
+<attribute name="CGCReceived" value="2005-12-27"/>
+<attribute name="genotype" value="unc-4(e120) ect-2(zh8) II; gap-1(ga133) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3021"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x3"/>
+<attribute name="primaryIdentifier" value="AH286"/>
+<attribute name="remark" value="Muv and Unc. Semi-dominant mutation in ect-2 (previously called let-21)."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_35"/><reference ref_id="4_49"/><reference ref_id="4_51"/></collection>
+<collection name="variations"><reference ref_id="5_47"/><reference ref_id="5_49"/><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_42" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="zfp-1(ok554) III; armIs8."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGK369"/>
+<attribute name="remark" value="armIs8 [zfp-1(short isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs8 transgene rescues the protruded vulva phenotype of zfp-1(ok554). Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_23"/></collection>
+<collection name="variations"><reference ref_id="5_20"/></collection>
+</item>
 <item id="3_14" class="Strain">
 <attribute name="primaryIdentifier" value="AGD855"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_87" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00002018"/>
+<item id="4_51" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006744"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_68"/><reference ref_id="3_69"/></collection>
+<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="5_75" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000436"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_84"/></collection>
+</item>
+<item id="3_69" class="Strain">
+<attribute name="laboratory" value="AK"/>
+<attribute name="primaryIdentifier" value="AK103"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_59"/></collection>
 </item>
 <item id="3_90" class="Strain">
 <attribute name="CGCReceived" value="2011-01-06"/>
@@ -1132,15 +1064,28 @@
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="5_19" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00087750"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<item id="4_80" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00016329"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+<collection name="strains"><reference ref_id="3_88"/></collection>
 </item>
 <item id="3_57" class="Strain">
 <attribute name="primaryIdentifier" value="AGP116"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_44" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx196."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson10009"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK532"/>
+<attribute name="remark" value="armEx196 [mex-5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to deletion of the niDF199 locus. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_15"/></collection>
 </item>
 <item id="3_10" class="Strain">
 <attribute name="CGCReceived" value="2015-05-28"/>
@@ -1152,26 +1097,7 @@
 <attribute name="remark" value="uthIs225 [sur5p::hsf-1(CT-Delta)::unc-54 3'UTR + myo-2p::tdTomato::unc-54 3' UTR]. Long-lived, thermotolerant. Small brood size. Reference: Baird NA, et al. Science. 2014 Oct 17;346(6207):360-3."/>
 <attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_11"/></collection>
-</item>
-<item id="3_66" class="Strain">
-<attribute name="CGCReceived" value="2016-02-18"/>
-<attribute name="genotype" value="unc-119(ed3) III; zhIs35 I."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="mutagen" value="Bombardment"/>
-<attribute name="outcrossed" value="x2"/>
-<attribute name="primaryIdentifier" value="AH1747"/>
-<attribute name="remark" value="zhIs35 [let-23::GFP + unc-119(+)] I. zhIs35 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene expression is higher in this strain than in AH1779 unc-119(ed3) III; zhIs38. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/></collection>
-</item>
-<item id="4_32" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00000912"/>
-<reference name="sequenceOntologyTerm" ref_id="6_1"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
+<collection name="genes"><reference ref_id="4_2"/></collection>
 </item>
 <item id="3_22" class="Strain">
 <attribute name="CGCReceived" value="2014-04-25"/>
@@ -1198,6 +1124,26 @@
 <attribute name="primaryIdentifier" value="ALF85"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
+<item id="3_88" class="Strain">
+<attribute name="CGCReceived" value="2004-10-14"/>
+<attribute name="genotype" value="osr-1(rm1) I."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3909"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x4"/>
+<attribute name="primaryIdentifier" value="AM1"/>
+<attribute name="remark" value="Osmotic stress resistant. Received new stock May 7, 2008."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_80"/></collection>
+<collection name="variations"><reference ref_id="5_77"/></collection>
+</item>
+<item id="4_82" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009100"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_92"/><reference ref_id="3_93"/></collection>
+</item>
 <item id="3_5" class="Strain">
 <attribute name="primaryIdentifier" value="AGD631"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
@@ -1206,35 +1152,89 @@
 <attribute name="primaryIdentifier" value="AGK710"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="3_71" class="Strain">
-<attribute name="CGCReceived" value="2012-05-01"/>
-<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X."/>
-<attribute name="laboratory" value="CGC"/>
-<attribute name="madeBy" value="WBPerson4598"/>
-<attribute name="outcrossed" value="x0"/>
-<attribute name="primaryIdentifier" value="ALF3"/>
-<attribute name="remark" value="Daf-d. Unc."/>
-<attribute name="species" value="Caenorhabditis elegans"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
-<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
-</item>
-<item id="5_81" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00275468"/>
-<reference name="sequenceOntologyTerm" ref_id="6_2"/>
-<collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_64"/></collection>
-</item>
-<item id="4_83" class="Gene">
-<attribute name="primaryIdentifier" value="WBGene00009717"/>
+<item id="4_37" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000156"/>
 <reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_65"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
 </item>
-<item id="5_55" class="Allele">
-<attribute name="primaryIdentifier" value="WBVar00091768"/>
+<item id="4_6" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00004510"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+</item>
+<item id="3_50" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="daf-16(mu86) I; zdIs13 IV; armEx257."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson9913"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK650"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx257 [dpy-7p::daf-16b::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx257 rescues the daf-16(mu86) HSN undermigration phenotype. dpy-7p::daf-16b::tagRFP expression is localized to nuclei in hypodermal tissue during the comma, 1.5 and 2-fold stages, becoming cytoplasmic or perinuclear by the 3-fold stage and persisting into adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_14"/></collection>
+<collection name="variations"><reference ref_id="5_12"/></collection>
+</item>
+<item id="5_61" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241609"/>
 <reference name="sequenceOntologyTerm" ref_id="6_2"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
-<collection name="strains"><reference ref_id="3_47"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="3_63" class="Strain">
+<attribute name="CGCReceived" value="2005-10-26"/>
+<attribute name="genotype" value="sdn-1(zh20) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3021"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x6"/>
+<attribute name="primaryIdentifier" value="AH205"/>
+<attribute name="remark" value="Slightly Unc. Variably Egl. zh20 is a deletion in sdn-1. The sequence of the breakpoint is: TTTGCTTCACAC"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_46"/></collection>
+<collection name="variations"><reference ref_id="5_45"/></collection>
+</item>
+<item id="5_37" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275469"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="3_43" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="zfp-1(ok554) III; armIs9."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AGK370"/>
+<attribute name="remark" value="armIs9 [zfp-1(long isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs9 transgene rescues zfp-1(ok554)/nDf17 lethality. Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_23"/></collection>
+<collection name="variations"><reference ref_id="5_20"/></collection>
+</item>
+<item id="3_46" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="armSi1 II; unc-119(ed3) III."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson10009"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK541"/>
+<attribute name="remark" value="armSi1 [mex5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)] II. GFP expression from transgene is observed in the germline. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_17"/></collection>
+<collection name="variations"><reference ref_id="5_27"/><reference ref_id="5_15"/></collection>
+</item>
+<item id="3_83" class="Strain">
+<attribute name="genotype" value="F42D1.2(baf1) X."/>
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF103"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_76"/></collection>
+<collection name="variations"><reference ref_id="5_73"/></collection>
 </item>
 </items>

--- a/bio/sources/wormbase-acedb/test/resources/WormbaseAcedbConverterTest_tgt.xml
+++ b/bio/sources/wormbase-acedb/test/resources/WormbaseAcedbConverterTest_tgt.xml
@@ -1,88 +1,1240 @@
 <items>
-<item id="8_1" class="CrossReference">
-<attribute name="identifier" value="11111"/>
-<reference name="source" ref_id="1_1"/>
-<reference name="subject" ref_id="7_1"/>
-</item>
-<item id="9_1" class="SOTerm">
-<attribute name="name" value="gene"/>
-<reference name="ontology" ref_id="0_1"/>
+<item id="3_8" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="uthEx299."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson5137"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD731"/>
+<attribute name="remark" value="uthEx299 [aak-2 (genomic aa1-aa321)::GFP::unc-54 3'UTR + myo-2p::tdTomato]. Pick animals with red pharynx to maintain. Reference: Mair W, et al. Nature. 2011 Feb 17;470(7334):404-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="6_1" class="Organism">
-<attribute name="taxonId" value="7227"/>
+<item id="5_76" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275470"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_62"/></collection>
 </item>
-<item id="11_1" class="InteractionDetail">
-<attribute name="name" value="interaction Short Label"/>
-<attribute name="relationshipType" value="direct interaction"/>
-<attribute name="role1" value="prey"/>
-<attribute name="role2" value="bait"/>
-<attribute name="type" value="physical"/>
-<reference name="experiment" ref_id="5_1"/>
-<reference name="interaction" ref_id="10_1"/>
-<collection name="allInteractors"><reference ref_id="7_2"/><reference ref_id="7_1"/></collection>
+<item id="3_98" class="Strain">
+<attribute name="CGCReceived" value="2011-01-06"/>
+<attribute name="genotype" value="rmIs175."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson5812"/>
+<attribute name="mutagen" value="Gamma irradiation"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM263"/>
+<attribute name="remark" value="rmIs175 [unc-54p::Hsa-sod-1 (WT)::YFP]. Array encodes wild-type human SOD-1. YFP expression in body wall muscle. Array is prone to silencing; maintain by picking worms displaying typical aggregation patterns. Reference: Gidalevitz T, et al., PLoS Genet. 2009 Mar;5(3):e1000399."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="4_1" class="InteractionTerm">
-<attribute name="identifier" value="MI:0018"/>
+<item id="4_71" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006765"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="3_32" class="Strain">
+<attribute name="primaryIdentifier" value="AGK51"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="7_1" class="Gene">
-<attribute name="primaryIdentifier" value="FBgn001"/>
-<reference name="organism" ref_id="6_1"/>
-<reference name="sequenceOntologyTerm" ref_id="9_1"/>
-<collection name="crossReferences"><reference ref_id="8_1"/></collection>
+<item id="4_112" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00016329"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_88"/></collection>
+</item>
+<item id="3_9" class="Strain">
+<attribute name="primaryIdentifier" value="AGD745"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
-<item id="10_2" class="Interaction">
-<reference name="participant1" ref_id="7_1"/>
-<reference name="participant2" ref_id="7_2"/>
-</item>
-<item id="11_2" class="InteractionDetail">
-<attribute name="name" value="interaction Short Label"/>
-<attribute name="relationshipType" value="direct interaction"/>
-<attribute name="role1" value="bait"/>
-<attribute name="role2" value="prey"/>
-<attribute name="type" value="physical"/>
-<reference name="experiment" ref_id="5_1"/>
-<reference name="interaction" ref_id="10_2"/>
-<collection name="allInteractors"><reference ref_id="7_2"/><reference ref_id="7_1"/></collection>
+<item id="4_107" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001843"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_84"/></collection>
 </item>
-<item id="8_2" class="CrossReference">
-<attribute name="identifier" value="12345"/>
-<reference name="source" ref_id="1_1"/>
-<reference name="subject" ref_id="7_2"/>
-</item>
-<item id="7_2" class="Gene">
-<attribute name="primaryIdentifier" value="FBgn002"/>
-<reference name="organism" ref_id="6_1"/>
-<reference name="sequenceOntologyTerm" ref_id="9_1"/>
-<collection name="crossReferences"><reference ref_id="8_2"/></collection>
+<item id="3_72" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs4."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF4"/>
+<attribute name="remark" value="bafIs4 [daf-12 fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
 <collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
 </item>
-<item id="2_1" class="DataSet">
-<attribute name="name" value="BioGRID interaction data set"/>
-<reference name="dataSource" ref_id="1_1"/>
+<item id="3_27" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="daf-16(mu86) I; glp-1(e2141) III; uthEx649."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1048"/>
+<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_32"/><reference ref_id="4_28"/></collection>
+<collection name="variations"><reference ref_id="5_31"/><reference ref_id="5_27"/></collection>
 </item>
-<item id="10_1" class="Interaction">
-<reference name="participant1" ref_id="7_2"/>
-<reference name="participant2" ref_id="7_1"/>
+<item id="5_31" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00089216"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
+</item>
+<item id="3_78" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs62."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson14558"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF82"/>
+<attribute name="remark" value="bafIs62 [lin-42p::GFP + unc-119(+)]. lin-42p::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+). Array was crossed into strain ALF3 to create ALF82. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
+</item>
+<item id="5_78" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275474"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_63"/></collection>
+</item>
+<item id="4_101" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00019620"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_80"/><reference ref_id="3_81"/><reference ref_id="3_82"/></collection>
+</item>
+<item id="5_53" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar02141399"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_46"/></collection>
+</item>
+<item id="5_90" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241522"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="4_76" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00005039"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_62"/></collection>
+</item>
+<item id="4_73" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00003043"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_61"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_94" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs126."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM134"/>
+<attribute name="remark" value="rmIs126 [unc-54p::Q0::YFP]. Diffuse distribution of Q0::YFP throughout the body-wall muscle cells. [NOTE: (04/29/13) Strain is reported as incorrect -- apparently carries 20Q transgene. Working on obtaining a replacement.]"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_120"/></collection>
+</item>
+<item id="4_11" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002004"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_10"/></collection>
 </item>
 <item id="0_1" class="Ontology">
 <attribute name="name" value="Sequence Ontology"/>
 <attribute name="url" value="http://www.sequenceontology.org"/>
 </item>
-<item id="3_1" class="Publication">
-<attribute name="pubMedId" value="14605208"/>
+<item id="3_16" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="rmIs284; uthEx633."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD867"/>
+<attribute name="remark" value="rmIs284 [F25B3.3p::Q67::YFP]. uthEx633 [myo-3p::GFP]. All animals will express YFP in nervous system; pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_50" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="daf-16(mu86) I; zdIs13 IV; armEx257."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson9913"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK650"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx257 [dpy-7p::daf-16b::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx257 rescues the daf-16(mu86) HSN undermigration phenotype. dpy-7p::daf-16b::tagRFP expression is localized to nuclei in hypodermal tissue during the comma, 1.5 and 2-fold stages, becoming cytoplasmic or perinuclear by the 3-fold stage and persisting into adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_32"/></collection>
+<collection name="variations"><reference ref_id="5_31"/></collection>
+</item>
+<item id="4_91" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000908"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="3_60" class="Strain">
+<attribute name="CGCReceived" value="2001-05-21"/>
+<attribute name="genotype" value="lip-1(zh15) IV."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson2597"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x8"/>
+<attribute name="primaryIdentifier" value="AH102"/>
+<attribute name="remark" value="Deletion allele which removes exons 2 to 6 of lip-1 (C05B10.1). Incompletely penetrant ovulation defect."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_73"/></collection>
+<collection name="variations"><reference ref_id="5_73"/></collection>
+</item>
+<item id="3_45" class="Strain">
+<attribute name="genotype" value="unc-119(ed3) III; armEx199."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK537"/>
+<attribute name="remark" value="armEx199 [cdl-1p::cdl-1::GFP + unc-119(+)]. Pick non-Unc to maintain. Nuclear localization of CDL-1::GFP in the germline and early embryos; strong enrichement of CDL-1::GFP in the nuclei of developing oocytes. Reference: Avgousti DC, et al. EMBO J. 2012 Oct 3;31(19):3821-32."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_88" class="Strain">
+<attribute name="CGCReceived" value="2004-10-14"/>
+<attribute name="genotype" value="osr-1(rm1) I."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3909"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x4"/>
+<attribute name="primaryIdentifier" value="AM1"/>
+<attribute name="remark" value="Osmotic stress resistant. Received new stock May 7, 2008."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_112"/></collection>
+<collection name="variations"><reference ref_id="5_111"/></collection>
+</item>
+<item id="4_44" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006975"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
+</item>
+<item id="3_80" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF100"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_101"/></collection>
+</item>
+<item id="3_58" class="Strain">
+<attribute name="CGCReceived" value="1997-12-08"/>
+<attribute name="genotype" value="gap-1(ga133) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson232"/>
+<attribute name="mutagen" value="Psoralen"/>
+<attribute name="outcrossed" value="x4"/>
+<attribute name="primaryIdentifier" value="AH12"/>
+<attribute name="remark" value="Null allele."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_68"/></collection>
+<collection name="variations"><reference ref_id="5_68"/></collection>
+</item>
+<item id="3_96" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs132 I."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM140"/>
+<attribute name="remark" value="rmIs132 [unc-54p::Q35::YFP]. AM140 animals show a Q35::YFP progressive transition from soluble to aggregated as they age."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_120"/></collection>
+</item>
+<item id="3_40" class="Strain">
+<attribute name="primaryIdentifier" value="AGK339"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="6_2" class="SOTerm">
+<attribute name="name" value="allele"/>
+<reference name="ontology" ref_id="0_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_111" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241620"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_88"/></collection>
+</item>
+<item id="5_71" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00143722"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="3_18" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx557."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD886"/>
+<attribute name="remark" value="uthEx557 [sur-5p::rpn-6 + myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_19"/><reference ref_id="4_20"/></collection>
+<collection name="variations"><reference ref_id="5_18"/><reference ref_id="5_19"/></collection>
+</item>
+<item id="3_95" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs130 II."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM138"/>
+<attribute name="remark" value="rmIs130 [unc-54p::Q24::YFP]. Diffuse distribution of Q24::YFP throughout the body-wall muscle cells."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_35" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00145093"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="3_29" class="Strain">
+<attribute name="CGCReceived" value="2015-05-28"/>
+<attribute name="genotype" value="uthIs372."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson24011"/>
+<attribute name="outcrossed" value="x7"/>
+<attribute name="primaryIdentifier" value="AGD1101"/>
+<attribute name="remark" value="uthIs372 [sur5p::pat-10::unc-54 3'UTR + myo-2p::tdTomato::unc-54 3' UTR]. Long-lived, thermotolerant. Reference: Baird NA, et al. Science. 2014 Oct 17;346(6207):360-3."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_63" class="Strain">
+<attribute name="CGCReceived" value="2005-10-26"/>
+<attribute name="genotype" value="sdn-1(zh20) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3021"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x6"/>
+<attribute name="primaryIdentifier" value="AH205"/>
+<attribute name="remark" value="Slightly Unc. Variably Egl. zh20 is a deletion in sdn-1. The sequence of the breakpoint is: TTTGCTTCACAC"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_78"/></collection>
+<collection name="variations"><reference ref_id="5_78"/></collection>
+</item>
+<item id="6_1" class="SOTerm">
+<attribute name="name" value="gene"/>
+<reference name="ontology" ref_id="0_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_21" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="uthIs270."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson16214"/>
+<attribute name="outcrossed" value="x8"/>
+<attribute name="primaryIdentifier" value="AGD927"/>
+<attribute name="remark" value="uthIs270 [rab-3p::xbp-1s (constitutively active) + myo-2p::tdTomato]. Pick animals with red pharynx to maintain. Reference: Taylor RC, Dillin A. Cell. 2013 Jun 20;153(7):1435-47."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_100" class="Strain">
+<attribute name="primaryIdentifier" value="AM470"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_43" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="zfp-1(ok554) III; armIs9."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AGK370"/>
+<attribute name="remark" value="armIs9 [zfp-1(long isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs9 transgene rescues zfp-1(ok554)/nDf17 lethality. Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_44"/></collection>
+<collection name="variations"><reference ref_id="5_43"/></collection>
+</item>
+<item id="3_93" class="Strain">
+<attribute name="laboratory" value="AM"/>
+<attribute name="primaryIdentifier" value="AM102"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_117"/></collection>
+</item>
+<item id="4_70" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000156"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="3_26" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="glp-1(e2141) III; uthEx649."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1047"/>
+<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Temperature-sensitive. Maintain at 15C; sterile at 25C. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_28"/></collection>
+<collection name="variations"><reference ref_id="5_27"/></collection>
+</item>
+<item id="4_28" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001609"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
+</item>
+<item id="3_37" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="zfp-1(ok554) unc-119(ed3) III; armEx14."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK280"/>
+<attribute name="remark" value="armEx14 [PHD1-PHD2::FLAG + zfp-1(short isoform) + unc-119(+)]. Pick non-Unc animals to maintain. The fosmid-based armEx14 transgene rescues zfp-1(ok554)/nDf17 lethality. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/><reference ref_id="4_44"/></collection>
+<collection name="variations"><reference ref_id="5_43"/><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_77" class="Strain">
+<attribute name="primaryIdentifier" value="ALF72"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_51" class="Strain">
+<attribute name="primaryIdentifier" value="AGK688"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_87" class="Strain">
+<attribute name="primaryIdentifier" value="ALF116"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_89" class="Strain">
+<attribute name="primaryIdentifier" value="AM23"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_6" class="Strain">
+<attribute name="primaryIdentifier" value="AGD638"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_68" class="Strain">
+<attribute name="laboratory" value="AK"/>
+<attribute name="primaryIdentifier" value="AK100"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_87"/></collection>
+</item>
+<item id="3_99" class="Strain">
+<attribute name="primaryIdentifier" value="AM265"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_46" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="armSi1 II; unc-119(ed3) III."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson10009"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK541"/>
+<attribute name="remark" value="armSi1 [mex5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)] II. GFP expression from transgene is observed in the germline. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_53"/><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_62" class="Strain">
+<attribute name="CGCReceived" value="2003-12-16"/>
+<attribute name="genotype" value="sra-13(zh13) II."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x8"/>
+<attribute name="primaryIdentifier" value="AH159"/>
+<attribute name="remark" value="sra-13(zh13) mutants display stronger chemotaxis to limiting concentrations of isoamylalcohol and diacetyl than WT animals. Deletion allele. 396 bp of 5' promoter sequence and all but the last exon are removed; probably a null allele."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_76"/></collection>
+<collection name="variations"><reference ref_id="5_76"/></collection>
+</item>
+<item id="3_13" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="rmIs284; uthEx557."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD851"/>
+<attribute name="remark" value="rmIs284 [F25B3.3p::Q67::YFP]. uthEx557 [sur-5p::rpn-6 + myo-3p::GFP]. All animals will express YFP in nervous system; pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_91" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00241609"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="3_36" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx53."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK234"/>
+<attribute name="remark" value="armEx53 [WRM0611aH08 + unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. This strain contains a transgenic array that expresses the WRM0611aH08 fosmid construct. This fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. Expression of this fosmid construct in JU258 worms restores the expression of the missing 21U-RNAs in the germline, as measured by RT-qPCR. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="5_27" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00144590"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_24"/><reference ref_id="3_25"/><reference ref_id="3_26"/><reference ref_id="3_27"/></collection>
+</item>
+<item id="5_104" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000435"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_83"/></collection>
+</item>
+<item id="4_117" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009100"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_92"/><reference ref_id="3_93"/></collection>
+</item>
+<item id="3_33" class="Strain">
+<attribute name="primaryIdentifier" value="AGK128"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_2" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="uthEx556."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD597"/>
+<attribute name="remark" value="uthEx556 [sur-5p::rpn-6 + myo-3p::GFP]. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_86" class="Strain">
+<attribute name="primaryIdentifier" value="ALF115"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
 </item>
 <item id="1_1" class="DataSource">
-<attribute name="name" value="BioGRID"/>
+<attribute name="name" value="AceDB XML"/>
 </item>
-<item id="5_1" class="InteractionExperiment">
-<attribute name="description" value="A protein interaction map of Drosophila melanogaster."/>
-<attribute name="name" value="Giot L (2003)"/>
-<reference name="publication" ref_id="3_1"/>
-<collection name="interactionDetectionMethods"><reference ref_id="4_1"/></collection>
+<item id="3_92" class="Strain">
+<attribute name="CGCReceived" value="2011-01-06"/>
+<attribute name="genotype" value="rmIs110."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3267"/>
+<attribute name="mutagen" value="Gamma irradiation"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AM101"/>
+<attribute name="remark" value="rmIs110 [F25B3.3p::Q40::YFP]. Pan-neuronal YFP expression. Reference: Gidalevitz T, et al., Science. 2006 Mar 10;311(5766):1471-4."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_117"/></collection>
+</item>
+<item id="3_28" class="Strain">
+<attribute name="primaryIdentifier" value="AGD1079"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_70" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275469"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_59"/></collection>
+</item>
+<item id="3_19" class="Strain">
+<attribute name="primaryIdentifier" value="AGD925"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_91" class="Strain">
+<attribute name="CGCReceived" value="2011-01-06"/>
+<attribute name="genotype" value="rmIs172."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma irradiation"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM49"/>
+<attribute name="remark" value="rmIs172 [F25B3.3p::Q19::CFP]. Pan-neuronal CFP expression. Reference: Gidalevitz T, et al., Science. 2006 Mar 10;311(5766):1471-4."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_56" class="Strain">
+<attribute name="primaryIdentifier" value="AGP28c"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_76" class="Strain">
+<attribute name="primaryIdentifier" value="ALF70"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_39" class="Strain">
+<attribute name="primaryIdentifier" value="AGK336"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_30" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="unc-119(ed3) III; armEx5."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK26"/>
+<attribute name="remark" value="armEx5 [zfp-1(fosmid)::GFP + unc-119(+)]. Pick non-Unc to maintain. Fosmid-based zfp-1::GFP transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. Nuclear expression of zfp-1::GFP is observed ubiquitously in somatic cells in all developmental stages; high levels of GFP expression is observed in oocytes with lower levels of expression in the distal germline. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_64" class="Strain">
+<attribute name="CGCReceived" value="2005-12-27"/>
+<attribute name="genotype" value="unc-4(e120) ect-2(zh8) II; gap-1(ga133) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson3021"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x3"/>
+<attribute name="primaryIdentifier" value="AH286"/>
+<attribute name="remark" value="Muv and Unc. Semi-dominant mutation in ect-2 (previously called let-21)."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_68"/><reference ref_id="4_80"/><reference ref_id="4_81"/></collection>
+<collection name="variations"><reference ref_id="5_80"/><reference ref_id="5_81"/><reference ref_id="5_68"/></collection>
+</item>
+<item id="3_61" class="Strain">
+<attribute name="CGCReceived" value="2001-05-21"/>
+<attribute name="genotype" value="zhIs4 III."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson2597"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AH142"/>
+<attribute name="remark" value="zhIs4 [lip-1::GFP] III. lip-1::GFP transcriptional reporter expression is upregulated in the secondary VPCs P5.p and P7.p of early L3 animals."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_73"/></collection>
+</item>
+<item id="3_12" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="rmIs110; uthEx557."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD850"/>
+<attribute name="remark" value="rmIs110 [F25B3.3p::Q40::YFP]. uthEx557 [sur5p::rpn-6 + myo3p::GFP]. All animals will express YFP in nervous system; pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_67" class="Strain">
+<attribute name="CGCReceived" value="2016-02-18"/>
+<attribute name="genotype" value="unc-119(ed3) III; zhIs38 IV."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Bombardment"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AH1779"/>
+<attribute name="remark" value="zhIs38 [let-23::GFP + unc-119(+)] IV. zhIs38 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene is expressed at levels similar to endogenous LET-23. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_31" class="Strain">
+<attribute name="primaryIdentifier" value="AGK29"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="2_1" class="DataSet">
+<attribute name="name" value="WormBaseAcedbConverter"/>
+<reference name="dataSource" ref_id="1_1"/>
+</item>
+<item id="3_17" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="rrf-3(b26) II; fem-1(hc17) IV; uthEx633."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD885"/>
+<attribute name="remark" value="uthEx633 [myo-3p::GFP]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_19"/><reference ref_id="4_20"/></collection>
+<collection name="variations"><reference ref_id="5_18"/><reference ref_id="5_19"/></collection>
+</item>
+<item id="3_4" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="uthEx633."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD614"/>
+<attribute name="remark" value="uthEx633 [myo-3p::GFP]. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_70" class="Strain">
+<attribute name="primaryIdentifier" value="AL132"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_34" class="Strain">
+<attribute name="CGCReceived" value="2013-11-20"/>
+<attribute name="genotype" value="unc-119(ed3) III; zdIs13 IV; armIs5."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK192"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armIs5 [zfp-1(fosmid)::FLAG + unc-119(+)]. Integrated zfp-1 transgene expressed in the germline. Fosmid-based zfp-1::FLAG transgene fully rescues stress-sensitivity and reduced lifespan in zfp-1(ok554) homozygotes. ChIP with anti-FLAG antibody detects ZFP-1::FLAG localization to promoters of highly expressed genes. References: Mansisidor AR, et al. PLoS Genet. 2011 Sep;7(9):e1002299. Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015. Cecere G, et al. Mol Cell. 2013 Jun 27;50(6):894-907."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="5_106" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000436"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_84"/></collection>
+</item>
+<item id="3_41" class="Strain">
+<attribute name="primaryIdentifier" value="AGK343"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_20" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00004510"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+</item>
+<item id="3_73" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X; bafIs9."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF9"/>
+<attribute name="remark" value="bafIs9 [daf-12::TAP fosmid carrying unc-119(+)]; rescues both daf-12 and unc-119. TAP tag insertedinto daf-12 fosmid. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
+</item>
+<item id="5_18" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00000354"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+</item>
+<item id="3_84" class="Strain">
+<attribute name="genotype" value="hgo-1(baf2) I."/>
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF104"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_107"/></collection>
+<collection name="variations"><reference ref_id="5_106"/></collection>
+</item>
+<item id="3_42" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="zfp-1(ok554) III; armIs8."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGK369"/>
+<attribute name="remark" value="armIs8 [zfp-1(short isoform)::FLAG::GFP + (pRF4) rol-6(su1006)]. Rollers. The fosmid-based armIs8 transgene rescues the protruded vulva phenotype of zfp-1(ok554). Ubiquitous nuclear localization of zfp-1(long isoform)::FLAG::GFP is observed in somatic cells in all developmental stages, but is silenced in the germline. See AGK26 for germline-expressing zfp-1::GFP. Reference: Avgousti DC, et al. Mol Cell Biol. 2013 Mar;33(5):999-1015."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_44"/></collection>
+<collection name="variations"><reference ref_id="5_43"/></collection>
+</item>
+<item id="3_35" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx58."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK233"/>
+<attribute name="remark" value="armEx58 [WRM0611aH08-Del8mer + unc-119(+)]. Pick non-Unc to maintain. This strain contains a transgenic array that expresses a derivative WRM0611aH08 fosmid. The WRM0611aH08 fosmid contains the niDF199 locus (around 4 kb) that is deleted in the natural C. elegans isolate strain JU258. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to this deletion of the niDF199 locus. This derivative fosmid construct lacks the upstream 8-mer motif (CTGTTTCA) next to 21U-3372. The expression of this individual 21U-RNA is lost in transgenic animals. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_69" class="Strain">
+<attribute name="laboratory" value="AK"/>
+<attribute name="primaryIdentifier" value="AK103"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_87"/></collection>
+</item>
+<item id="3_38" class="Strain">
+<attribute name="primaryIdentifier" value="AGK335"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_3" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="uthEx557."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD598"/>
+<attribute name="remark" value="uthEx557 [sur-5p::rpn-6 + myo-3p::GFP]. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_53" class="Strain">
+<attribute name="primaryIdentifier" value="AGK690"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_120" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006789"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_94"/><reference ref_id="3_96"/><reference ref_id="3_97"/></collection>
+</item>
+<item id="3_20" class="Strain">
+<attribute name="CGCReceived" value="2015-05-28"/>
+<attribute name="genotype" value="zcIs4 V; uthIs269."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson16214"/>
+<attribute name="outcrossed" value="x5+"/>
+<attribute name="primaryIdentifier" value="AGD926"/>
+<attribute name="remark" value="zcIs4 [hsp-4::GFP] V. uthIs269 [sur5p::hsf-1::unc-54 3'UTR + myo-2p::tdTomato::unc-54 3' UTR]. ER stress resistence. Reference: Taylor RC, Dillin A. Cell. 2013 Jun 20;153(7):1435-47."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_23" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="uthEx650."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD946"/>
+<attribute name="remark" value="uthEx650 [rpn-6p::tdTomato + rol-6(su1006)]. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_59" class="Strain">
+<attribute name="CGCReceived" value="2000-07-24"/>
+<attribute name="genotype" value="apr-1(zh10) unc-29(e1072) I; zhEx11."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson232"/>
+<attribute name="mutagen" value="EMS"/>
+<attribute name="outcrossed" value="x6"/>
+<attribute name="primaryIdentifier" value="AH75"/>
+<attribute name="remark" value="zhEx11[apr-1(+) + sur-5::GFP]. Unc. Segregates dead eggs that have lost the rescuing array."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_70"/><reference ref_id="4_71"/></collection>
+<collection name="variations"><reference ref_id="5_70"/><reference ref_id="5_71"/></collection>
+</item>
+<item id="3_83" class="Strain">
+<attribute name="genotype" value="F42D1.2(baf1) X."/>
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF103"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_105"/></collection>
+<collection name="variations"><reference ref_id="5_104"/></collection>
+</item>
+<item id="4_68" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001515"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
+</item>
+<item id="3_15" class="Strain">
+<attribute name="CGCReceived" value="2013-09-18"/>
+<attribute name="genotype" value="rmIs110; uthEx633."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGD866"/>
+<attribute name="remark" value="rmIs110 [F25B3.3p::Q40::YFP]. uthEx633 [myo-3p::GFP]. All animals will express YFP in nervous system; pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_19" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00001411"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+</item>
+<item id="3_52" class="Strain">
+<attribute name="primaryIdentifier" value="AGK689"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_78" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00004749"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_63"/></collection>
+</item>
+<item id="4_58" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00003911"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_49"/></collection>
+</item>
+<item id="5_83" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275477"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_47" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="otIs225 II; daf-18(ok480) IV; armEx218."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson9913"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK573"/>
+<attribute name="remark" value="otIs225 [cat-4::GFP] II. armEx218 [unc-119p::daf-18 + unc-119p::tagRFP + rol-6(su1006)]. Pick Rollers to maintain. Transgenic array expresses DAF-18 from unc-119 pan-neuronal promoter; rescues the HSN undermigration phenotype in daf-18 null mutants. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_55"/></collection>
+<collection name="variations"><reference ref_id="5_55"/></collection>
+</item>
+<item id="3_44" class="Strain">
+<attribute name="CGCReceived" value="2014-12-16"/>
+<attribute name="genotype" value="unc-119(ed3) III; niDf199 IV; armEx196."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson10009"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK532"/>
+<attribute name="remark" value="armEx196 [mex-5p::unc-130::GFP::tbb-2 3'UTR + Cbr-unc-119(+)]. Pick non-Unc to maintain. unc-119(ed3) was crossed into JU258, the niDf199IV deletion was confirmed by PCR, and these Unc worms were used for bombardment. JU258 worms lack specific 21U-RNAs normally present in N2 worms due to deletion of the niDF199 locus. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45. Reference: Cecere G, et al. Mol Cell. 2012 Sep 14;47(5):734-45."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="3_75" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; bafIs63."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson14558"/>
+<attribute name="outcrossed" value="x1"/>
+<attribute name="primaryIdentifier" value="ALF63"/>
+<attribute name="remark" value="bafIs63 [lin-42p(mut)::GFP + unc-119(+)]. lin-42p(mut)::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+); all potential DAF-12 binding sites have been mutated. Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="4_36" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006843"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_30"/><reference ref_id="3_34"/><reference ref_id="3_35"/><reference ref_id="3_36"/><reference ref_id="3_37"/><reference ref_id="3_44"/><reference ref_id="3_45"/><reference ref_id="3_46"/><reference ref_id="3_66"/><reference ref_id="3_67"/><reference ref_id="3_71"/><reference ref_id="3_72"/><reference ref_id="3_73"/><reference ref_id="3_75"/><reference ref_id="3_78"/></collection>
+</item>
+<item id="4_55" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000913"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_47"/></collection>
+</item>
+<item id="4_80" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002297"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/></collection>
+</item>
+<item id="3_82" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF102"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_101"/></collection>
+</item>
+<item id="4_81" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00006744"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="5_58" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091739"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_49"/></collection>
+</item>
+<item id="5_80" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00142975"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_1" class="Strain">
+<attribute name="primaryIdentifier" value="AGD568"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_25" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="glp-1(e2141) III; xzEx3."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1033"/>
+<attribute name="remark" value="xzEx3 [unc-54p::UbG76V::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_28"/></collection>
+<collection name="variations"><reference ref_id="5_27"/></collection>
+</item>
+<item id="3_81" class="Strain">
+<attribute name="laboratory" value="ALF"/>
+<attribute name="primaryIdentifier" value="ALF101"/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_101"/></collection>
+</item>
+<item id="3_74" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="bafIs62."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson14558"/>
+<attribute name="mutagen" value="Bombardment"/>
+<attribute name="outcrossed" value="x4"/>
+<attribute name="primaryIdentifier" value="ALF62"/>
+<attribute name="remark" value="bafIs62 [lin-42p::GFP + unc-119(+)]. lin-42p::GFP reporter consists of 2 kb upstream of lin-42a isoform subcloned into modified pPD95.75 vector also carrying unc-119(+). Reference: Hochbaum D, et al. PLoS Genet. 2011 Jul;7(7):e1002179."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_49" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="zdIs13 IV; pak-1(ok448) X; armEx252."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson9913"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGK640"/>
+<attribute name="remark" value="zdIs13 [tph-1p::GFP] IV. armEx252 [dpy-7p::pak-1::tagRFP + myo-2::GFP]. Pick animals with GFP+ pharynx to maintain. armEx252 rescues the pak-1(ok480) HSN undermigration phenotype. pak-1::tagRFP is expressed in the hypodermal tissue throughout development and adulthood. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_58"/></collection>
+<collection name="variations"><reference ref_id="5_58"/></collection>
+</item>
+<item id="4_105" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009628"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_83"/></collection>
+</item>
+<item id="3_55" class="Strain">
+<attribute name="primaryIdentifier" value="AGK711"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_24" class="Strain">
+<attribute name="CGCReceived" value="2013-11-22"/>
+<attribute name="genotype" value="glp-1(e2141) III; xzEx1."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD1032"/>
+<attribute name="remark" value="xzEx1 [unc-54p::Dendra2]. Maintain at 15C; sterile at 25C. Pick animals with GFP expression in body wall muscle to maintain. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_28"/></collection>
+<collection name="variations"><reference ref_id="5_27"/></collection>
+</item>
+<item id="3_97" class="Strain">
+<attribute name="CGCReceived" value="2005-04-05"/>
+<attribute name="genotype" value="rmIs133."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma Rays"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM141"/>
+<attribute name="remark" value="rmIs133 [unc-54p::Q40::YFP]. AM141 animals show a soluble Q40::YFP distribution in body wall muscle cells immediately after hatching. As these worms age the rapid formation of foci is observed. When they reach adulthood, AM141 animals show an entirely Q40::YFP aggregated phenotype."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_120"/></collection>
+</item>
+<item id="5_68" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00145428"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_58"/><reference ref_id="3_64"/></collection>
+</item>
+<item id="5_73" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275471"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_60"/><reference ref_id="3_65"/></collection>
+</item>
+<item id="3_65" class="Strain">
+<attribute name="CGCReceived" value="2005-12-27"/>
+<attribute name="genotype" value="dep-1(zh34) unc-4(e120) II; lip-1(zh15) IV."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson2597"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AH346"/>
+<attribute name="remark" value="Pvl and weak Muv. Transformation of secondary to primary vulval cell fates."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_73"/><reference ref_id="4_81"/><reference ref_id="4_83"/></collection>
+<collection name="variations"><reference ref_id="5_83"/><reference ref_id="5_80"/><reference ref_id="5_73"/></collection>
+</item>
+<item id="3_85" class="Strain">
+<attribute name="primaryIdentifier" value="ALF110"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_11" class="Strain">
+<attribute name="primaryIdentifier" value="AGD803"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_43" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091841"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_37"/><reference ref_id="3_42"/><reference ref_id="3_43"/></collection>
+</item>
+<item id="3_7" class="Strain">
+<attribute name="CGCReceived" value="2015-05-29"/>
+<attribute name="genotype" value="uthIs235."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson24011"/>
+<attribute name="outcrossed" value="x2+"/>
+<attribute name="primaryIdentifier" value="AGD710"/>
+<attribute name="remark" value="uthIs235 [sur5p::hsf-1::unc-54 3'UTR + myo-2p::tdTomato::unc-54 3' UTR]. Long-lived, thermotolerant. Small brood size. Reference: Baird NA, et al. Science. 2014 Oct 17;346(6207):360-3."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_14" class="Strain">
+<attribute name="primaryIdentifier" value="AGD855"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="4_87" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00002018"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_68"/><reference ref_id="3_69"/></collection>
+</item>
+<item id="3_90" class="Strain">
+<attribute name="CGCReceived" value="2011-01-06"/>
+<attribute name="genotype" value="rmIs190."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Gamma irradiation"/>
+<attribute name="outcrossed" value="x5"/>
+<attribute name="primaryIdentifier" value="AM44"/>
+<attribute name="remark" value="rmIs190 [F25B3.3p::Q67::CFP]. Pan-neuronal CFP expression."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="5_19" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00087750"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_17"/><reference ref_id="3_18"/></collection>
+</item>
+<item id="3_57" class="Strain">
+<attribute name="primaryIdentifier" value="AGP116"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_10" class="Strain">
+<attribute name="CGCReceived" value="2015-05-28"/>
+<attribute name="genotype" value="hsf-1 (sy441) I; uthIs225."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson24011"/>
+<attribute name="outcrossed" value="x2+"/>
+<attribute name="primaryIdentifier" value="AGD794"/>
+<attribute name="remark" value="uthIs225 [sur5p::hsf-1(CT-Delta)::unc-54 3'UTR + myo-2p::tdTomato::unc-54 3' UTR]. Long-lived, thermotolerant. Small brood size. Reference: Baird NA, et al. Science. 2014 Oct 17;346(6207):360-3."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_11"/></collection>
+</item>
+<item id="3_66" class="Strain">
+<attribute name="CGCReceived" value="2016-02-18"/>
+<attribute name="genotype" value="unc-119(ed3) III; zhIs35 I."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="mutagen" value="Bombardment"/>
+<attribute name="outcrossed" value="x2"/>
+<attribute name="primaryIdentifier" value="AH1747"/>
+<attribute name="remark" value="zhIs35 [let-23::GFP + unc-119(+)] I. zhIs35 resuces let-23(sy1) and recapitulates LET-23 anitbody staining in VPCs. let-23::GFP transgene expression is higher in this strain than in AH1779 unc-119(ed3) III; zhIs38. Reference: Haag A, et al. PLoS Genet. 2014 May 1;10(5):e1004341."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/></collection>
+</item>
+<item id="4_32" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00000912"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_27"/><reference ref_id="3_50"/></collection>
+</item>
+<item id="3_22" class="Strain">
+<attribute name="CGCReceived" value="2014-04-25"/>
+<attribute name="genotype" value="uthEx649."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson18908"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="AGD945"/>
+<attribute name="remark" value="uthEx649 [rpn-6p::tdTomato + rol-6(su1006)]. Rollers. Pick rollers to maintain array. Reference: Vilchez D, et al. Nature. 2012 Sep 13;489(7415):263-8."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_48" class="Strain">
+<attribute name="CGCReceived" value="2013-12-16"/>
+<attribute name="genotype" value="armEx227."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="outcrossed" value="x"/>
+<attribute name="primaryIdentifier" value="AGK587"/>
+<attribute name="remark" value="armEx227 [pak-1p::NLS::tagRFP + rol-6(su1006)]. Pick rollers to maintain. pak-1p::NLS::tagRFP is expressed primarily in the hypodermal tissue during the comma and 1.5-fold stages, and in the CAN cells at the 3-fold stage through adulthood. Expression can also be seen in additional neurons during the larval and adult stages. Reference: Kennedy LM, et al. Cell Rep. 2013 Sep 12;4(5):996-1009."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_79" class="Strain">
+<attribute name="primaryIdentifier" value="ALF85"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_5" class="Strain">
+<attribute name="primaryIdentifier" value="AGD631"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_54" class="Strain">
+<attribute name="primaryIdentifier" value="AGK710"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+</item>
+<item id="3_71" class="Strain">
+<attribute name="CGCReceived" value="2012-05-01"/>
+<attribute name="genotype" value="unc-119(ed3) III; daf-12(rh61rh411) X."/>
+<attribute name="laboratory" value="CGC"/>
+<attribute name="madeBy" value="WBPerson4598"/>
+<attribute name="outcrossed" value="x0"/>
+<attribute name="primaryIdentifier" value="ALF3"/>
+<attribute name="remark" value="Daf-d. Unc."/>
+<attribute name="species" value="Caenorhabditis elegans"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="genes"><reference ref_id="4_91"/><reference ref_id="4_36"/></collection>
+<collection name="variations"><reference ref_id="5_35"/><reference ref_id="5_90"/><reference ref_id="5_91"/></collection>
+</item>
+<item id="5_81" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00275468"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_64"/></collection>
+</item>
+<item id="4_83" class="Gene">
+<attribute name="primaryIdentifier" value="WBGene00009717"/>
+<reference name="sequenceOntologyTerm" ref_id="6_1"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_65"/></collection>
+</item>
+<item id="5_55" class="Allele">
+<attribute name="primaryIdentifier" value="WBVar00091768"/>
+<reference name="sequenceOntologyTerm" ref_id="6_2"/>
+<collection name="dataSets"><reference ref_id="2_1"/></collection>
+<collection name="strains"><reference ref_id="3_47"/></collection>
 </item>
 </items>

--- a/bio/sources/wormbase-acedb/wormbase-acedb_additions.xml
+++ b/bio/sources/wormbase-acedb/wormbase-acedb_additions.xml
@@ -14,7 +14,7 @@
 	<class name="Gene" is-interface="true">
 		<attribute name="operon" type="java.lang.String"/>
 		<reference name="referenceAllele" referenced-type="Allele" />
-		<collection name="strains" referenced-type="Strain" reverse-reference="gene"/>
+		<collection name="strains" referenced-type="Strain" reverse-reference="genes"/>
 		<collection name="expressionPatterns" referenced-type="ExpressionPattern" reverse-reference="gene"/>
 		<collection name="expressionClusters" referenced-type="ExpressionCluster" reverse-reference="genes"/>
 		<collection name="regulatesExprCluster" referenced-type="ExpressionCluster" reverse-reference="regulatedByGene"/>
@@ -81,14 +81,14 @@
 	  <collection name="strains" referenced-type="Strain" reverse-reference="variations" />
 	  <collection name="fromLabs" referenced-type="Laboratory" reverse-reference="variations" />
 	  <!--  will handle when expanding variation -->
-	  <collection name="geneClass" referenced-type="GeneClass" reverse-reference="variations" /> 
+	  <collection name="geneClass" referenced-type="GeneClass" reverse-reference="variations" />
 	</class>
 
 	<class name="Laboratory" is-interface="true">
 	  <attribute name="primaryIdentifier" type="java.lang.String"/>
 	  <collection name="variations" referenced-type="Allele" reverse-reference="fromLabs" />
 	  <collection name="RNAis" referenced-type="RNAi" reverse-reference="laboratories"/>
-	  <collection name="geneClasses" referenced-type="GeneClass" reverse-reference="designatingLaboratory"/>		
+	  <collection name="geneClasses" referenced-type="GeneClass" reverse-reference="designatingLaboratory"/>
 	  <collection name="formerGeneClasses" referenced-type="GeneClass" reverse-reference="formerDesignatingLaboratory"/>
 	</class>
 
@@ -117,7 +117,7 @@
 	</class>
 	<class name="ExpressionPattern" is-interface="true">
 		<attribute name="primaryIdentifier" type="java.lang.String"/>
-		<attribute name="subcellularLocalization" type="java.lang.String"/> 
+		<attribute name="subcellularLocalization" type="java.lang.String"/>
 		<attribute name="pattern" type="java.lang.String"/>
 		<attribute name="remark" type="java.lang.String"/>
 		<attribute name="reporterGene" type="java.lang.String"/>
@@ -158,7 +158,7 @@
 	<class name="Process" is-interface="true">
 		<attribute name="primaryIdentifier" type="java.lang.String"/>
 		<collection name="expressionClusters" referenced-type="ExpressionCluster" reverse-reference="processes"/>
-		
+
 	</class>
 	<class name="LifeStage" is-interface="true">
 		<attribute name="primaryIdentifier" type="java.lang.String"/>
@@ -173,7 +173,7 @@
 		<collection name="anatomyTerms" referenced-type="AnatomyTerm" reverse-reference="lifeStages"/>
 		<collection name="expressionPatterns" referenced-type="ExpressionPattern" reverse-reference="lifeStages"/>
 		<collection name="expressionClusters" referenced-type="ExpressionCluster" reverse-reference="lifeStages"/>
-		
+
 	</class>
 
 	<class name="RNAi" extends="BioEntity" is-interface="true">
@@ -202,7 +202,7 @@
                 <attribute name="primaryIdentifier" type="java.lang.String"/>
 		<attribute name="genotype" type="java.lang.String"/>
 		<attribute name="otherName" type="java.lang.String"/>
-		<attribute name="inbreedingState" type="java.lang.String"/> 
+		<attribute name="inbreedingState" type="java.lang.String"/>
 		<attribute name="outcrossed" type="java.lang.String"/>
 		<attribute name="mutagen" type="java.lang.String"/>
 		<attribute name="strainHistory" type="java.lang.String"/>
@@ -211,11 +211,11 @@
 		<attribute name="laboratory" type="java.lang.String"/>
 		<attribute name="madeBy" type="java.lang.String"/>
 		<attribute name="remark" type="java.lang.String"/>
-		<attribute name="species" type="java.lang.String"/> 
-		<attribute name="ncbiTaxonomyID" type="java.lang.String"/> 
-		<reference name="gene" referenced-type="Gene" reverse-reference="strains"/>
+		<attribute name="species" type="java.lang.String"/>
+		<attribute name="ncbiTaxonomyID" type="java.lang.String"/>
+		<collection name="genes" referenced-type="Gene" reverse-reference="strains"/>
          <collection name="variations" referenced-type="Allele" reverse-reference="strains" />
-        </class> 
+        </class>
 
 
 </classes>


### PR DESCRIPTION
Sorry for all the whitespace updates, eclipse does that automatically.

This is a one line change, just removing the duplicate createItem call. You don't want to create an item twice. I don't think that is our problem but it could cause issues so best to remove. 